### PR TITLE
Add relative path option to ParseOptions

### DIFF
--- a/src/util/parse-options.cc
+++ b/src/util/parse-options.cc
@@ -28,6 +28,11 @@
 #include <cstdlib>
 #include <cassert>
 #include <cstring>
+#include <climits>
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
 
 #include "util/parse-options.h"
 #include "util/text-utils.h"
@@ -38,7 +43,8 @@ namespace kaldi {
 
 ParseOptions::ParseOptions(const std::string &prefix,
                            OptionsItf *other):
-    print_args_(false), help_(false), usage_(""), argc_(0), argv_(NULL) {
+    print_args_(false), help_(false), anchor_dir_(""), usage_(""),
+    argc_(0), argv_(NULL) {
   ParseOptions *po = dynamic_cast<ParseOptions*>(other);
   if (po != NULL && po->other_parser_ != NULL) {
     // we get here if this constructor is used twice, recursively.
@@ -465,11 +471,27 @@ void ParseOptions::PrintConfig(std::ostream &os) {
   os << '\n';
 }
 
+std::string ParseOptions::ResolvePath(const std::string &relative) {
+  if (anchor_dir_ == "")
+        return relative;
+
+  struct stat info;
+  if (::stat(relative.c_str(), &info) == 0)
+    return relative;
+
+  char tmp[PATH_MAX];
+  std::string cat = anchor_dir_ + "/" + relative;
+  ::realpath(cat.c_str(), tmp);
+  return std::string(tmp);
+}
+
 
 void ParseOptions::ReadConfigFile(const std::string &filename) {
-  std::ifstream is(filename.c_str(), std::ifstream::in);
+  std::string full_path = ResolvePath(filename);
+
+  std::ifstream is(full_path.c_str(), std::ifstream::in);
   if (!is.good()) {
-    KALDI_ERR << "Cannot open config file: " << filename;
+    KALDI_ERR << "Cannot open config file: " << full_path;
   }
 
   std::string line, key, value;
@@ -486,7 +508,7 @@ void ParseOptions::ReadConfigFile(const std::string &filename) {
     if (line.length() == 0) continue;
 
     if (line.substr(0, 2) != "--") {
-      KALDI_ERR << "Reading config file " << filename
+      KALDI_ERR << "Reading config file " << full_path
                 << ": line " << line_number << " does not look like a line "
                 << "from a Kaldi command-line program's config file: should "
                 << "be of the form --x=y.  Note: config files intended to "
@@ -500,7 +522,7 @@ void ParseOptions::ReadConfigFile(const std::string &filename) {
     Trim(&value);
     if (!SetOption(key, value, has_equal_sign)) {
       PrintUsage(true);
-      KALDI_ERR << "Invalid option " << line << " in config file " << filename;
+      KALDI_ERR << "Invalid option " << line << " in config file " << full_path;
     }
   }
 }

--- a/src/util/parse-options.h
+++ b/src/util/parse-options.h
@@ -36,8 +36,8 @@ namespace kaldi {
 class ParseOptions : public OptionsItf {
  public:
   explicit ParseOptions(const char *usage) :
-    print_args_(true), help_(false), usage_(usage), argc_(0), argv_(NULL),
-    prefix_(""), other_parser_(NULL) {
+    print_args_(true), help_(false), anchor_dir_(""), usage_(usage),
+    argc_(0), argv_(NULL), prefix_(""), other_parser_(NULL) {
 #ifndef _MSC_VER  // This is just a convenient place to set the stderr to line
     setlinebuf(stderr);  // buffering mode, since it's called at program start.
 #endif  // This helps ensure different programs' output is not mixed up.
@@ -127,6 +127,15 @@ class ParseOptions : public OptionsItf {
   std::string GetOptArg(int param) const {
     return (param <= NumArgs() ? GetArg(param) : "");
   }
+
+  void SetAnchorDir(const std::string &anchor) {
+      anchor_dir_ = anchor;
+  }
+
+  /// Resolve the relative path with the anchor_dir_ previously set
+  /// If anchor_dir_ is unset, relative is actually absolute, or the resolved
+  /// path does not exist return relative
+  std::string ResolvePath(const std::string &relative);
 
   /// The following function will return a possibly quoted and escaped
   /// version of "str", according to the current shell.  Currently
@@ -218,6 +227,7 @@ class ParseOptions : public OptionsItf {
   bool print_args_;     ///< variable for the implicit --print-args parameter
   bool help_;           ///< variable for the implicit --help parameter
   std::string config_;  ///< variable for the implicit --config parameter
+  std::string anchor_dir_; ///< Used to resolve any relative paths used in this config
   std::vector<std::string> positional_args_;
   const char *usage_;
   int argc_;


### PR DESCRIPTION
Using relative paths in config files today gives some odd behavior.  It
seems to attempt to resolve a relative path based on the $CWD of the
executable being run, but this does not always work.  This behavior is
not ideal when moving config files between experiments because it means
that all config files used must be updated for any paths that may have
changed.  This patch introduces a new field in the ParseOptions class
that allows the user to specify the "anchor" directory that will be
used to resolve any relative paths encountered.

This idea has been rejected by upstream, so if we want it, we will have to carry it.

Signed-off-by: Eric B Munson <eric@cobaltspeech.com>