### PR TITLE
Expand relative directory resolution

### DIFF
--- a/src/online2/online-ivector-feature.cc
+++ b/src/online2/online-ivector-feature.cc
@@ -27,7 +27,8 @@ OnlineIvectorExtractionInfo::OnlineIvectorExtractionInfo(
 }
 
 void OnlineIvectorExtractionInfo::Init(
-    const OnlineIvectorExtractionConfig &config) {
+    const OnlineIvectorExtractionConfig &config,
+    const std::string &config_anchor) {
   ivector_period = config.ivector_period;
   num_gselect = config.num_gselect;
   min_post = config.min_post;
@@ -47,22 +48,22 @@ void OnlineIvectorExtractionInfo::Init(
       "in the file supplied to --ivector-extractor-config)";
   if (config.lda_mat_rxfilename == "")
     KALDI_ERR << "--lda-matrix option must be set " << note;
-  ReadKaldiObject(config.lda_mat_rxfilename, &lda_mat);
+  ReadKaldiObject(ParseOptions::ResolvePath(config_anchor, config.lda_mat_rxfilename), &lda_mat);
   if (config.global_cmvn_stats_rxfilename == "")
     KALDI_ERR << "--global-cmvn-stats option must be set " << note;
-  ReadKaldiObject(config.global_cmvn_stats_rxfilename, &global_cmvn_stats);
+  ReadKaldiObject(ParseOptions::ResolvePath(config_anchor, config.global_cmvn_stats_rxfilename), &global_cmvn_stats);
   if (config.cmvn_config_rxfilename == "")
     KALDI_ERR << "--cmvn-config option must be set " << note;
-  ReadConfigFromFile(config.cmvn_config_rxfilename, &cmvn_opts);
+  ReadConfigFromFile(ParseOptions::ResolvePath(config_anchor, config.cmvn_config_rxfilename), &cmvn_opts);
   if (config.splice_config_rxfilename == "")
     KALDI_ERR << "--splice-config option must be set " << note;
-  ReadConfigFromFile(config.splice_config_rxfilename, &splice_opts);
+  ReadConfigFromFile(ParseOptions::ResolvePath(config_anchor, config.splice_config_rxfilename), &splice_opts);
   if (config.diag_ubm_rxfilename == "")
     KALDI_ERR << "--diag-ubm option must be set " << note;
-  ReadKaldiObject(config.diag_ubm_rxfilename, &diag_ubm);
+  ReadKaldiObject(ParseOptions::ResolvePath(config_anchor, config.diag_ubm_rxfilename), &diag_ubm);
   if (config.ivector_extractor_rxfilename == "")
     KALDI_ERR << "--ivector-extractor option must be set " << note;
-  ReadKaldiObject(config.ivector_extractor_rxfilename, &extractor);
+  ReadKaldiObject(ParseOptions::ResolvePath(config_anchor, config.ivector_extractor_rxfilename), &extractor);
   this->Check();
 }
 

--- a/src/online2/online-ivector-feature.h
+++ b/src/online2/online-ivector-feature.h
@@ -182,7 +182,7 @@ struct OnlineIvectorExtractionInfo {
 
   OnlineIvectorExtractionInfo(const OnlineIvectorExtractionConfig &config);
 
-  void Init(const OnlineIvectorExtractionConfig &config);
+  void Init(const OnlineIvectorExtractionConfig &config, const std::string &config_anchor = "");
 
   // This constructor creates a version of this object where everything
   // is empty or zero.

--- a/src/online2/online-nnet2-feature-pipeline.cc
+++ b/src/online2/online-nnet2-feature-pipeline.cc
@@ -34,21 +34,21 @@ OnlineNnet2FeaturePipelineInfo::OnlineNnet2FeaturePipelineInfo(
   }
 
   if (config.mfcc_config != "") {
-    ReadConfigFromFile(config.mfcc_config, &mfcc_opts);
+    ReadConfigFromFile(config.mfcc_config, &mfcc_opts, config.config_anchor);
     if (feature_type != "mfcc")
       KALDI_WARN << "--mfcc-config option has no effect "
                  << "since feature type is set to " << feature_type << ".";
   }  // else use the defaults.
 
   if (config.plp_config != "") {
-    ReadConfigFromFile(config.plp_config, &plp_opts);
+    ReadConfigFromFile(config.plp_config, &plp_opts, config.config_anchor);
     if (feature_type != "plp")
       KALDI_WARN << "--plp-config option has no effect "
                  << "since feature type is set to " << feature_type << ".";
   }  // else use the defaults.
 
   if (config.fbank_config != "") {
-    ReadConfigFromFile(config.fbank_config, &fbank_opts);
+    ReadConfigFromFile(config.fbank_config, &fbank_opts, config.config_anchor);
     if (feature_type != "fbank")
       KALDI_WARN << "--fbank-config option has no effect "
                  << "since feature type is set to " << feature_type << ".";
@@ -57,9 +57,8 @@ OnlineNnet2FeaturePipelineInfo::OnlineNnet2FeaturePipelineInfo(
   add_pitch = config.add_pitch;
   
   if (config.online_pitch_config != "") {
-    ReadConfigsFromFile(config.online_pitch_config,
-                        &pitch_opts,
-                        &pitch_process_opts);
+    ReadConfigsFromFile(config.online_pitch_config, &pitch_opts,
+            &pitch_process_opts, config.config_anchor);
     if (!add_pitch)
       KALDI_WARN << "--online-pitch-config option has no effect "
                  << "since you did not supply --add-pitch option.";
@@ -69,8 +68,8 @@ OnlineNnet2FeaturePipelineInfo::OnlineNnet2FeaturePipelineInfo(
     use_ivectors = true;
     OnlineIvectorExtractionConfig ivector_extraction_opts;
     ReadConfigFromFile(config.ivector_extraction_config,
-                       &ivector_extraction_opts);
-    ivector_extractor_info.Init(ivector_extraction_opts);
+                       &ivector_extraction_opts, config.config_anchor);
+    ivector_extractor_info.Init(ivector_extraction_opts, config.config_anchor);
   } else {
     use_ivectors = false;
   }

--- a/src/online2/online-nnet2-feature-pipeline.h
+++ b/src/online2/online-nnet2-feature-pipeline.h
@@ -80,6 +80,9 @@ struct OnlineNnet2FeaturePipelineConfig {
   // OnlineIvectorExtractionConfig.
   std::string ivector_extraction_config;
 
+  // Anchor used for resolving relative config file names
+  std::string config_anchor;
+
   // Config that relates to how we weight silence for (ivector) adaptation
   // this is registered directly to the command line as you might want to
   // play with it in test time.

--- a/src/util/parse-options.cc
+++ b/src/util/parse-options.cc
@@ -471,8 +471,8 @@ void ParseOptions::PrintConfig(std::ostream &os) {
   os << '\n';
 }
 
-std::string ParseOptions::ResolvePath(const std::string &relative) {
-  if (anchor_dir_ == "")
+std::string ParseOptions::ResolvePath(const std::string &anchor, const std::string &relative) {
+  if (anchor == "")
         return relative;
 
   struct stat info;
@@ -480,14 +480,14 @@ std::string ParseOptions::ResolvePath(const std::string &relative) {
     return relative;
 
   char tmp[PATH_MAX];
-  std::string cat = anchor_dir_ + "/" + relative;
+  std::string cat = anchor + "/" + relative;
   ::realpath(cat.c_str(), tmp);
   return std::string(tmp);
 }
 
 
 void ParseOptions::ReadConfigFile(const std::string &filename) {
-  std::string full_path = ResolvePath(filename);
+  std::string full_path = ResolvePath(anchor_dir_, filename);
 
   std::ifstream is(full_path.c_str(), std::ifstream::in);
   if (!is.good()) {

--- a/src/util/parse-options.h
+++ b/src/util/parse-options.h
@@ -135,7 +135,7 @@ class ParseOptions : public OptionsItf {
   /// Resolve the relative path with the anchor_dir_ previously set
   /// If anchor_dir_ is unset, relative is actually absolute, or the resolved
   /// path does not exist return relative
-  std::string ResolvePath(const std::string &relative);
+  static std::string ResolvePath(const std::string &anchor, const std::string &relative);
 
   /// The following function will return a possibly quoted and escaped
   /// version of "str", according to the current shell.  Currently
@@ -245,11 +245,12 @@ class ParseOptions : public OptionsItf {
 /// "void Register(OptionsItf *po)" which it can call to register the
 /// ParseOptions object.
 template<class C> void ReadConfigFromFile(const std::string config_filename,
-                                          C *c) {
+                                          C *c, const std::string anchor = "") {
   std::ostringstream usage_str;
   usage_str << "Parsing config from "
             << "from '" << config_filename << "'";
   ParseOptions po(usage_str.str().c_str());
+  po.SetAnchorDir(anchor);
   c->Register(&po);
   po.ReadConfigFile(config_filename);
 }
@@ -257,11 +258,12 @@ template<class C> void ReadConfigFromFile(const std::string config_filename,
 /// This variant of the template ReadConfigFromFile is for if you need to read
 /// two config classes from the same file.
 template<class C1, class C2> void ReadConfigsFromFile(const std::string config_filename,
-                                                      C1 *c1, C2 *c2) {
+                                                      C1 *c1, C2 *c2, const std::string anchor = "") {
   std::ostringstream usage_str;
   usage_str << "Parsing config from "
             << "from '" << config_filename << "'";
   ParseOptions po(usage_str.str().c_str());
+  po.SetAnchorDir(anchor);
   c1->Register(&po);
   c2->Register(&po);
   po.ReadConfigFile(config_filename);


### PR DESCRIPTION
We use the kaldi front end and cannot wrap the config loading code.
Instead, adjust the config object to plumb the anchor path specified
when the top level config was loaded all the way down.

Signed-off-by: Eric B Munson <eric@cobaltspeech.com>