### PR TITLE
Makeing the destructor of AmNnet class virtual

### DIFF
--- a/src/nnet2/am-nnet.h
+++ b/src/nnet2/am-nnet.h
@@ -71,7 +71,7 @@ class AmNnet {
   /// This function is used when doing transfer learning to a new system.
   /// It will set the priors to be all the same. 
   void ResizeOutputLayer(int32 new_num_pdfs);
-  
+  virtual ~AmNnet(){}
  protected:
   const AmNnet &operator = (const AmNnet &other); // Disallow.
   Nnet nnet_;


### PR DESCRIPTION
The AmNnet has a virtual method but not a virtual destructor
this commit aims to add a virtual destructor for stopping
possible resource leaking
 Changes to be committed:
	modified:   nnet2/am-nnet.h