### PR TITLE
Add install target and libs only build

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -33,6 +33,14 @@ include kaldi.mk
 all: checkversion test_dependencies kaldi.mk mklibdir $(SUBDIRS)
 	-echo Done
 
+libs: checkversion test_dependencies kaldi.mk $(SUBDIRS_LIB)
+
+install_libs: libs
+	-for x in $(SUBDIRS_LIB); do $(MAKE) -C $$x $@; done
+
+install: all
+	-for x in $(SUBDIRS); do $(MAKE) -C $$x $@; done
+
 mklibdir:
 	test -d $(KALDILIBDIR) || mkdir $(KALDILIBDIR)
 
@@ -111,7 +119,7 @@ ext_test: $(addsuffix /test, $(EXT_SUBDIRS))
 
 # Define an implicit rule, expands to e.g.:
 #  base/test: base
-#     $(MAKE) -C base test 
+#     $(MAKE) -C base test
 %/test: % mklibdir
 	$(MAKE) -C $< test
 
@@ -134,10 +142,14 @@ ext_depend: check_portaudio
 
 .PHONY: $(SUBDIRS)
 $(SUBDIRS) : mklibdir
-	$(MAKE) -C $@ 
+	$(MAKE) -C $@
 
 .PHONY: $(EXT_SUBDIRS)
 $(EXT_SUBDIRS) : mklibdir
+	$(MAKE) -C $@
+
+.PHONY: $(SUBDIRS_LIB)
+$(SUBDIRS_LIB) : mklibdir
 	$(MAKE) -C $@
 
 
@@ -166,10 +178,10 @@ hmm: base tree matrix util
 lm: base util fstext
 decoder: base util matrix gmm sgmm hmm tree transform lat
 lat: base util hmm tree matrix
-cudamatrix: base util matrix	
+cudamatrix: base util matrix
 nnet: base util matrix cudamatrix
 nnet2: base util matrix thread lat gmm hmm tree transform cudamatrix
-ivector: base util matrix thread transform tree gmm 
+ivector: base util matrix thread transform tree gmm
 #3)Dependencies for optional parts of Kaldi
 onlinebin: base matrix util feat tree optimization gmm transform sgmm sgmm2 fstext hmm lm decoder lat cudamatrix nnet nnet2 online thread
 online2bin: base matrix util feat tree optimization gmm transform sgmm sgmm2 fstext hmm lm decoder lat cudamatrix nnet nnet2 online2 thread ivector

--- a/src/configure
+++ b/src/configure
@@ -59,6 +59,7 @@ fi
 MATHLIB='ATLAS'
 ATLASROOT=`rel2abs ../tools/ATLAS/`
 FSTROOT=`rel2abs ../tools/openfst`
+PREFIX=/usr/local/
 
 # Avoid using any variables that are set in the shell.
 unset MKLROOT
@@ -70,7 +71,8 @@ function usage {
   echo 'Usage: ./configure [--static|--shared] [--threaded-atlas={yes|no}] [--atlas-root=ATLASROOT] [--fst-root=FSTROOT]
   [--openblas-root=OPENBLASROOOT] [--clapack-root=CLAPACKROOT] [--mkl-root=MKLROOT] [--mkl-libdir=MKLLIBDIR]
   [--omp-libdir=OMPDIR] [--static-fst={yes|no}] [--static-math={yes|no}] [--threaded-math={yes|no}] [--mathlib=ATLAS|MKL|CLAPACK|OPENBLAS]
-  [--use-cuda={yes|no}] [--cudatk-dir=CUDATKDIR] [--android_openblas={yes|no} [--linux-arm={yes|no}] [--host=HOST]';
+  [--use-cuda={yes|no}] [--cudatk-dir=CUDATKDIR] [--android_openblas={yes|no} [--linux-arm={yes|no}] [--host=HOST]
+  [--prefix=PREFIXDIR]';
 }
 
 threaded_atlas=false #  By default, use the un-threaded version of ATLAS.
@@ -143,6 +145,9 @@ do
   linux_arm=true; shift;;
   --host=*)
   HOST=`expr "X$1" : '[^=]*=\(.*\)'`-; shift ;;
+  --prefix=*)
+  # Don't use read_dirname, because prefix does not need to exist yet, we will create it
+  PREFIX=`expr "X$1" : '[^=]*=\(.*\)'`; shift ;;
   --cudatk-dir=*)
   CUDATKDIR=`read_dirname $1`; shift ;; #CUDA is used in src/cudamatrix and src/nnet{,bin} only
   *)  echo "Unknown argument: $1, exiting"; usage; exit 1 ;;
@@ -729,6 +734,7 @@ echo "KALDILIBDIR := $KALDILIBDIR" >> kaldi.mk
 fi
 echo "CONFIGURE_VERSION := $CONFIGURE_VERSION" >> kaldi.mk
 echo "FSTROOT = $FSTROOT" >> kaldi.mk
+echo "PREFIX = $PREFIX" >> kaldi.mk
 
 # Check installed OpenFst version and add C++11 flags if OpenFst >= 1.4
 OPENFST_VER=1.3.4

--- a/src/makefiles/default_rules.mk
+++ b/src/makefiles/default_rules.mk
@@ -29,6 +29,10 @@ else
   XDEPENDS = $(ADDLIBS)
 endif
 
+HEADERS = $(shell ls *.h)
+
+INC_DIR = $(shell basename $(CURDIR))
+
 all: $(LIBFILE) $(BINFILES)
 
 $(LIBFILE): $(OBJFILES)
@@ -53,6 +57,13 @@ endif
 
 $(BINFILES): $(LIBFILE) $(XDEPENDS)
 
+install_libs: $(LIBFILE)
+	-for x in $(LIBFILE);  do install -D -m 0644 $$x $(PREFIX)/lib/$$x; done
+	-for x in $(HEADERS); do install -D -m 0644 $$x $(PREFIX)/include/$(INC_DIR)/$$x; done
+
+install: $(BINFILES) install_libs
+	-for x in $(BINFILES); do install -D -m 0755 $$x $(PREFIX)/bin/$$x; done
+
 
 # Rule below would expand to, e.g.:
 # ../base/kaldi-base.a:
@@ -70,7 +81,7 @@ clean:
 $(TESTFILES): $(LIBFILE) $(XDEPENDS)
 
 test_compile: $(TESTFILES)
-  
+
 test: test_compile
 	@result=0; for x in $(TESTFILES); do printf "Running $$x ..."; ./$$x >/dev/null 2>&1; if [ $$? -ne 0 ]; then echo "... FAIL $$x"; result=1; else echo "... SUCCESS";  fi;  done; exit $$result
 
@@ -78,7 +89,7 @@ test: test_compile
 
 
 depend:
-	-$(CXX) -M $(CXXFLAGS) *.cc > .depend.mk  
+	-$(CXX) -M $(CXXFLAGS) *.cc > .depend.mk
 
 # removing automatic making of "depend" as it's quite slow.
 #.depend.mk: depend


### PR DESCRIPTION
For use in rubik, we do not need to go through and build all the binary
tools for kaldi and building the libraries only is significantly
faster.  Make a target that allows the building of only the libraries.

Also, add targets to install everything or only the libraries.  This
requires the addition of a new configure variable, prefix, which
defaults to /usr/local.

Signed-off-by: Eric B Munson <eric@cobaltspeech.com>