### PR TITLE
Update android build script

### DIFF
--- a/src/install_android_openblas.sh
+++ b/src/install_android_openblas.sh
@@ -7,7 +7,6 @@ TOOLCHAIN_INCLUDE=${3:-/tmp/my-android-toolchain/sysroot/usr/include/}
 OPENBLAS_ROOT=${4:-/opt/arm-tools}
 
 export TOOLCHAIN_PREFIX=$TOOLCHAIN_PREFIX
-export TOOLCHAIN_INCLUDE=$TOOLCHAIN_INCLUDE
 
 export CPP=${TOOLCHAIN_PREFIX}-cpp
 export AR=${TOOLCHAIN_PREFIX}-ar
@@ -18,8 +17,8 @@ export CXX=${TOOLCHAIN_PREFIX}-g++
 export LD=${TOOLCHAIN_PREFIX}-ld
 export RANLIB=${TOOLCHAIN_PREFIX}-ranlib
 
-./configure --android-openblas=yes --fst-root=/opt/arm-tools/ --openblas-root=$OPENBLAS_ROOT
+./configure --android-openblas=yes --fst-root=/opt/arm-tools/ --openblas-root=$OPENBLAS_ROOT \
+	--toolchain-includes=$TOOLCHAIN_INCLUDE --prefix=$INSTALL_PREFIX
 
-make -j7
-make install
-python ../install_kaldi.py . $INSTALL_PREFIX
+make libs -j7
+make install_libs


### PR DESCRIPTION
In configuring the kaldi configure script and build system to support
our android build chain in Jenkins, I broke the
install_android_openblas.sh script.  This should make the changes needed
to work with the new configure options.  As a bonus, we now have targets
for building and installing only the kaldi libraries.

Signed-off-by: Eric B Munson <eric@cobaltspeech.com>