### PR TITLE
Bug fix for Kaldi Error Message in Windows

### DIFF
--- a/src/base/kaldi-error.h
+++ b/src/base/kaldi-error.h
@@ -27,7 +27,7 @@
 #include <sstream>
 #include <cstdio>
 
-#if _MSC_VER >= 0x1400 || !defined(MSC_VER) && __cplusplus > 199711L || defined(__GXX_EXPERIMENTAL_CXX0X__)
+#if _MSC_VER >= 1400 || !defined(MSC_VER) && __cplusplus > 199711L || defined(__GXX_EXPERIMENTAL_CXX0X__)
 #define NOEXCEPT(Predicate) noexcept((Predicate))
 #else
 #define NOEXCEPT(Predicate)


### PR DESCRIPTION
There is a bug in kaldi-error which leads to an error of Unhandled
exception when calling KALDI-ERR function.

The bug locates on _MSC_VER checking and that leads to wrong NOEXCEPT
definition.

	modified:   src/base/kaldi-error.h