### PR TITLE
cblas-wrappers and cblas changes for clapack

### DIFF
--- a/kaldi_clapack_arm/kaldiwin/kaldi-base/kaldi-base.vcxproj
+++ b/kaldi_clapack_arm/kaldiwin/kaldi-base/kaldi-base.vcxproj
@@ -115,7 +115,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;HAVE_CLAPACK;NO_PTHREAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
@@ -123,6 +123,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+      <AdditionalIncludeDirectories>C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
@@ -155,20 +156,24 @@
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;HAVE_CLAPACK;NO_PTHREAD;HAVE_OPENBLAS 0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <AdditionalIncludeDirectories>$(OPENFST)\src\include;C:\kaldi\tools\CLAPACK;C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
+    <Lib>
+      <AdditionalLibraryDirectories>C:\opt\local\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+    </Lib>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WINDOWS_ARM;HAVE_CLAPACK;_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WINDOWS_ARM;HAVE_CLAPACK;_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE;NO_PTHREAD</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>

--- a/kaldi_clapack_arm/kaldiwin/kaldi-base/kaldi-base.vcxproj
+++ b/kaldi_clapack_arm/kaldiwin/kaldi-base/kaldi-base.vcxproj
@@ -73,36 +73,40 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
     <Import Project="..\kaldiwin_win32.props" />
     <Import Project="..\openfstwin_debug_win32.props" />
+    <Import Project="..\kaldiwin_arm.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'" Label="PropertySheets">
     <Import Project="..\variables.props" />
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
     <Import Project="..\kaldiwin_win32.props" />
     <Import Project="..\openfstwin_debug_win32.props" />
+    <Import Project="..\kaldiwin_arm.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
     <Import Project="..\variables.props" />
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
     <Import Project="..\kaldiwin.props" />
     <Import Project="..\openfstwin_debug.props" />
+    <Import Project="..\kaldiwin_arm.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
     <Import Project="..\variables.props" />
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
     <Import Project="..\kaldiwin_win32.props" />
     <Import Project="..\openfstwin_release_win32.props" />
+    <Import Project="..\kaldiwin_arm.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'" Label="PropertySheets">
     <Import Project="..\variables.props" />
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-    <Import Project="..\kaldiwin_win32.props" />
-    <Import Project="..\openfstwin_release_win32.props" />
+    <Import Project="..\kaldiwin_arm.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
     <Import Project="..\variables.props" />
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
     <Import Project="..\kaldiwin.props" />
     <Import Project="..\openfstwin_release.props" />
+    <Import Project="..\kaldiwin_arm.props" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
@@ -115,7 +119,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;HAVE_CLAPACK;NO_PTHREAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
@@ -123,7 +127,6 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
-      <AdditionalIncludeDirectories>C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
@@ -156,31 +159,25 @@
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;HAVE_CLAPACK;NO_PTHREAD;HAVE_OPENBLAS 0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <AdditionalIncludeDirectories>$(OPENFST)\src\include;C:\kaldi\tools\CLAPACK;C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
-    <Lib>
-      <AdditionalLibraryDirectories>C:\opt\local\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-    </Lib>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WINDOWS_ARM;HAVE_CLAPACK;_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE;NO_PTHREAD</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <AdditionalIncludeDirectories>../../../tools/CLAPACK/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">

--- a/kaldi_clapack_arm/kaldiwin/kaldi-cudamatrix/kaldi-cudamatrix.vcxproj
+++ b/kaldi_clapack_arm/kaldiwin/kaldi-cudamatrix/kaldi-cudamatrix.vcxproj
@@ -95,8 +95,7 @@
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'" Label="PropertySheets">
     <Import Project="..\variables.props" />
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-    <Import Project="..\kaldiwin_win32.props" />
-    <Import Project="..\openfstwin_release_win32.props" />
+    <Import Project="..\kaldiwin_arm.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
     <Import Project="..\variables.props" />
@@ -115,7 +114,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;HAVE_CLAPACK;NO_PTHREAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
@@ -123,7 +122,6 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
-      <AdditionalIncludeDirectories>$(OPENFST)\src\include\;C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
@@ -156,14 +154,13 @@
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;HAVE_CLAPACK;NO_PTHREAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <AdditionalIncludeDirectories>$(OPENFST)\src\include;../../../tools/CLAPACK/;C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
@@ -176,8 +173,6 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <AdditionalIncludeDirectories>../../../tools/CLAPACK/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WINDOWS_ARM;HAVE_CLAPACK;_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -194,6 +189,7 @@
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="..\..\..\src\cudamatrix\cu-array.cc" />
     <ClCompile Include="..\..\..\src\cudamatrix\cu-block-matrix.cc" />
     <ClCompile Include="..\..\..\src\cudamatrix\cu-common.cc" />
     <ClCompile Include="..\..\..\src\cudamatrix\cu-device.cc" />
@@ -206,6 +202,8 @@
     <ClCompile Include="..\..\..\src\cudamatrix\cu-vector.cc" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\..\..\src\cudamatrix\cu-array-inl.h" />
+    <ClInclude Include="..\..\..\src\cudamatrix\cu-array.h" />
     <ClInclude Include="..\..\..\src\cudamatrix\cu-block-matrix.h" />
     <ClInclude Include="..\..\..\src\cudamatrix\cu-common.h" />
     <ClInclude Include="..\..\..\src\cudamatrix\cu-device.h" />

--- a/kaldi_clapack_arm/kaldiwin/kaldi-cudamatrix/kaldi-cudamatrix.vcxproj
+++ b/kaldi_clapack_arm/kaldiwin/kaldi-cudamatrix/kaldi-cudamatrix.vcxproj
@@ -115,7 +115,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;HAVE_CLAPACK;NO_PTHREAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
@@ -123,6 +123,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+      <AdditionalIncludeDirectories>$(OPENFST)\src\include\;C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
@@ -155,13 +156,14 @@
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;HAVE_CLAPACK;NO_PTHREAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <AdditionalIncludeDirectories>$(OPENFST)\src\include;../../../tools/CLAPACK/;C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">

--- a/kaldi_clapack_arm/kaldiwin/kaldi-cudamatrix/kaldi-cudamatrix.vcxproj.filters
+++ b/kaldi_clapack_arm/kaldiwin/kaldi-cudamatrix/kaldi-cudamatrix.vcxproj.filters
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="Source Files">
@@ -49,6 +49,9 @@
     <ClCompile Include="..\..\..\src\cudamatrix\cu-vector.cc">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\src\cudamatrix\cu-array.cc">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\src\cudamatrix\cu-block-matrix.h">
@@ -82,6 +85,12 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\src\cudamatrix\cu-vector.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\src\cudamatrix\cu-array.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\src\cudamatrix\cu-array-inl.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/kaldi_clapack_arm/kaldiwin/kaldi-decoder/kaldi-decoder.vcxproj
+++ b/kaldi_clapack_arm/kaldiwin/kaldi-decoder/kaldi-decoder.vcxproj
@@ -115,7 +115,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;HAVE_CLAPACK;NO_PTHREAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
@@ -123,6 +123,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+      <AdditionalIncludeDirectories>$(OPENFST)\src\include\;C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
@@ -155,13 +156,14 @@
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;HAVE_CLAPACK;NO_PTHREAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <AdditionalIncludeDirectories>$(OPENFST)\src\include;C:\kaldi\tools\CLAPACK;C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">

--- a/kaldi_clapack_arm/kaldiwin/kaldi-decoder/kaldi-decoder.vcxproj
+++ b/kaldi_clapack_arm/kaldiwin/kaldi-decoder/kaldi-decoder.vcxproj
@@ -95,8 +95,7 @@
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'" Label="PropertySheets">
     <Import Project="..\variables.props" />
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-    <Import Project="..\kaldiwin_win32.props" />
-    <Import Project="..\openfstwin_release_win32.props" />
+    <Import Project="..\kaldiwin_arm.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
     <Import Project="..\variables.props" />
@@ -115,7 +114,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;HAVE_CLAPACK;NO_PTHREAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
@@ -123,7 +122,6 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
-      <AdditionalIncludeDirectories>$(OPENFST)\src\include\;C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
@@ -156,28 +154,25 @@
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;HAVE_CLAPACK;NO_PTHREAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <AdditionalIncludeDirectories>$(OPENFST)\src\include;C:\kaldi\tools\CLAPACK;C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WINDOWS_ARM;HAVE_CLAPACK;_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <AdditionalIncludeDirectories>../../../tools/openfst/src/include/;../../../tools/CLAPACK/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">

--- a/kaldi_clapack_arm/kaldiwin/kaldi-feat/kaldi-feat.vcxproj
+++ b/kaldi_clapack_arm/kaldiwin/kaldi-feat/kaldi-feat.vcxproj
@@ -115,7 +115,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;HAVE_CLAPACK;NO_PTHREAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
@@ -123,6 +123,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+      <AdditionalIncludeDirectories>$(OPENFST)\src\include\;C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
@@ -155,13 +156,14 @@
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;HAVE_CLAPACK;NO_PTHREAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <AdditionalIncludeDirectories>$(OPENFST)\src\include;C:\kaldi\tools\CLAPACK;C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">

--- a/kaldi_clapack_arm/kaldiwin/kaldi-feat/kaldi-feat.vcxproj
+++ b/kaldi_clapack_arm/kaldiwin/kaldi-feat/kaldi-feat.vcxproj
@@ -95,8 +95,7 @@
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'" Label="PropertySheets">
     <Import Project="..\variables.props" />
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-    <Import Project="..\kaldiwin_win32.props" />
-    <Import Project="..\openfstwin_release_win32.props" />
+    <Import Project="..\kaldiwin_arm.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
     <Import Project="..\variables.props" />
@@ -115,7 +114,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;HAVE_CLAPACK;NO_PTHREAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
@@ -123,7 +122,6 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
-      <AdditionalIncludeDirectories>$(OPENFST)\src\include\;C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
@@ -156,28 +154,25 @@
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;HAVE_CLAPACK;NO_PTHREAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <AdditionalIncludeDirectories>$(OPENFST)\src\include;C:\kaldi\tools\CLAPACK;C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WINDOWS_ARM;HAVE_CLAPACK;_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <AdditionalIncludeDirectories>../../../tools/CLAPACK/;../../../tools/openfst/src/include/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -199,6 +194,7 @@
     <ClCompile Include="..\..\..\src\feat\feature-mfcc.cc" />
     <ClCompile Include="..\..\..\src\feat\feature-plp.cc" />
     <ClCompile Include="..\..\..\src\feat\feature-spectrogram.cc" />
+    <ClCompile Include="..\..\..\src\feat\feature-window.cc" />
     <ClCompile Include="..\..\..\src\feat\mel-computations.cc" />
     <ClCompile Include="..\..\..\src\feat\online-feature.cc" />
     <ClCompile Include="..\..\..\src\feat\pitch-functions.cc" />
@@ -207,11 +203,13 @@
     <ClCompile Include="..\..\..\src\feat\wave-reader.cc" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\..\..\src\feat\feature-common.h" />
     <ClInclude Include="..\..\..\src\feat\feature-fbank.h" />
     <ClInclude Include="..\..\..\src\feat\feature-functions.h" />
     <ClInclude Include="..\..\..\src\feat\feature-mfcc.h" />
     <ClInclude Include="..\..\..\src\feat\feature-plp.h" />
     <ClInclude Include="..\..\..\src\feat\feature-spectrogram.h" />
+    <ClInclude Include="..\..\..\src\feat\feature-window.h" />
     <ClInclude Include="..\..\..\src\feat\mel-computations.h" />
     <ClInclude Include="..\..\..\src\feat\online-feature.h" />
     <ClInclude Include="..\..\..\src\feat\pitch-functions.h" />

--- a/kaldi_clapack_arm/kaldiwin/kaldi-feat/kaldi-feat.vcxproj.filters
+++ b/kaldi_clapack_arm/kaldiwin/kaldi-feat/kaldi-feat.vcxproj.filters
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="Source Files">
@@ -52,6 +52,9 @@
     <ClCompile Include="..\..\..\src\feat\wave-reader.cc">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\src\feat\feature-window.cc">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\src\feat\feature-fbank.h">
@@ -85,6 +88,12 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\src\feat\wave-reader.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\src\feat\feature-window.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\src\feat\feature-common.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/kaldi_clapack_arm/kaldiwin/kaldi-fstext/kaldi-fstext.vcxproj
+++ b/kaldi_clapack_arm/kaldiwin/kaldi-fstext/kaldi-fstext.vcxproj
@@ -115,7 +115,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;HAVE_CLAPACK;NO_PTHREAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
@@ -123,6 +123,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+      <AdditionalIncludeDirectories>$(OPENFST)\src\include\;C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
@@ -155,13 +156,14 @@
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;HAVE_CLAPACK;NO_PTHREAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <AdditionalIncludeDirectories>$(OPENFST)\src\include;C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">

--- a/kaldi_clapack_arm/kaldiwin/kaldi-fstext/kaldi-fstext.vcxproj
+++ b/kaldi_clapack_arm/kaldiwin/kaldi-fstext/kaldi-fstext.vcxproj
@@ -95,8 +95,7 @@
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'" Label="PropertySheets">
     <Import Project="..\variables.props" />
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-    <Import Project="..\kaldiwin_win32.props" />
-    <Import Project="..\openfstwin_release_win32.props" />
+    <Import Project="..\kaldiwin_arm.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
     <Import Project="..\variables.props" />
@@ -115,7 +114,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;HAVE_CLAPACK;NO_PTHREAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
@@ -123,7 +122,6 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
-      <AdditionalIncludeDirectories>$(OPENFST)\src\include\;C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
@@ -156,28 +154,25 @@
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;HAVE_CLAPACK;NO_PTHREAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <AdditionalIncludeDirectories>$(OPENFST)\src\include;C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WINDOWS_ARM;HAVE_CLAPACK;_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <AdditionalIncludeDirectories>../../../tools/openfst/src/include/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">

--- a/kaldi_clapack_arm/kaldiwin/kaldi-gmm/kaldi-gmm.vcxproj
+++ b/kaldi_clapack_arm/kaldiwin/kaldi-gmm/kaldi-gmm.vcxproj
@@ -95,8 +95,7 @@
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'" Label="PropertySheets">
     <Import Project="..\variables.props" />
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-    <Import Project="..\kaldiwin_win32.props" />
-    <Import Project="..\openfstwin_release_win32.props" />
+    <Import Project="..\kaldiwin_arm.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
     <Import Project="..\variables.props" />
@@ -115,7 +114,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;HAVE_CLAPACK;NO_PTHREAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
@@ -123,7 +122,6 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
-      <AdditionalIncludeDirectories>$(OPENFST)\src\include\;C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
@@ -156,28 +154,25 @@
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;HAVE_CLAPACK;NO_PTHREAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <AdditionalIncludeDirectories>$(OPENFST)\src\include;C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WINDOWS_ARM;HAVE_CLAPACK;_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE;NO_PTHREAD</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <AdditionalIncludeDirectories>../../../../pthreads-w32/pthreads.2;../../../tools/CLAPACK/;../../../tools/openfst/src/include/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">

--- a/kaldi_clapack_arm/kaldiwin/kaldi-gmm/kaldi-gmm.vcxproj
+++ b/kaldi_clapack_arm/kaldiwin/kaldi-gmm/kaldi-gmm.vcxproj
@@ -115,7 +115,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;HAVE_CLAPACK;NO_PTHREAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
@@ -123,6 +123,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+      <AdditionalIncludeDirectories>$(OPENFST)\src\include\;C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
@@ -155,20 +156,21 @@
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;HAVE_CLAPACK;NO_PTHREAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <AdditionalIncludeDirectories>$(OPENFST)\src\include;C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WINDOWS_ARM;HAVE_CLAPACK;_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WINDOWS_ARM;HAVE_CLAPACK;_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE;NO_PTHREAD</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>

--- a/kaldi_clapack_arm/kaldiwin/kaldi-hmm/kaldi-hmm.vcxproj
+++ b/kaldi_clapack_arm/kaldiwin/kaldi-hmm/kaldi-hmm.vcxproj
@@ -115,7 +115,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;HAVE_CLAPACK;NO_PTHREAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
@@ -123,6 +123,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+      <AdditionalIncludeDirectories>$(OPENFST)\src\include\;C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
@@ -155,20 +156,21 @@
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;HAVE_CLAPACK;NO_PTHREAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <AdditionalIncludeDirectories>$(OPENFST)\src\include;C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WINDOWS_ARM;HAVE_CLAPACK;_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WINDOWS_ARM;HAVE_CLAPACK;_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE;NO_PTHREAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>

--- a/kaldi_clapack_arm/kaldiwin/kaldi-hmm/kaldi-hmm.vcxproj
+++ b/kaldi_clapack_arm/kaldiwin/kaldi-hmm/kaldi-hmm.vcxproj
@@ -95,8 +95,7 @@
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'" Label="PropertySheets">
     <Import Project="..\variables.props" />
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-    <Import Project="..\kaldiwin_win32.props" />
-    <Import Project="..\openfstwin_release_win32.props" />
+    <Import Project="..\kaldiwin_arm.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
     <Import Project="..\variables.props" />
@@ -115,7 +114,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;HAVE_CLAPACK;NO_PTHREAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
@@ -123,7 +122,6 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
-      <AdditionalIncludeDirectories>$(OPENFST)\src\include\;C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
@@ -156,28 +154,25 @@
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;HAVE_CLAPACK;NO_PTHREAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <AdditionalIncludeDirectories>$(OPENFST)\src\include;C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WINDOWS_ARM;HAVE_CLAPACK;_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE;NO_PTHREAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <AdditionalIncludeDirectories>../../../tools/openfst/src/include/;../../../tools/CLAPACK/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">

--- a/kaldi_clapack_arm/kaldiwin/kaldi-ivector/kaldi-ivector.vcxproj
+++ b/kaldi_clapack_arm/kaldiwin/kaldi-ivector/kaldi-ivector.vcxproj
@@ -95,8 +95,7 @@
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'" Label="PropertySheets">
     <Import Project="..\variables.props" />
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-    <Import Project="..\kaldiwin_win32.props" />
-    <Import Project="..\openfstwin_release_win32.props" />
+    <Import Project="..\kaldiwin_arm.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
     <Import Project="..\variables.props" />
@@ -115,7 +114,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;HAVE_CLAPACK;NO_PTHREAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
@@ -123,7 +122,6 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
-      <AdditionalIncludeDirectories>$(OPENFST)\src\include\;C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
@@ -156,28 +154,25 @@
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;HAVE_CLAPACK;NO_PTHREAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <AdditionalIncludeDirectories>$(OPENFST)\src\include;C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WINDOWS_ARM;HAVE_CLAPACK;_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <AdditionalIncludeDirectories>../../../../pthreads-w32/pthreads.2/;../../../tools/CLAPACK/;../../../tools/openfst/src/include/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">

--- a/kaldi_clapack_arm/kaldiwin/kaldi-ivector/kaldi-ivector.vcxproj
+++ b/kaldi_clapack_arm/kaldiwin/kaldi-ivector/kaldi-ivector.vcxproj
@@ -115,7 +115,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;HAVE_CLAPACK;NO_PTHREAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
@@ -123,6 +123,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+      <AdditionalIncludeDirectories>$(OPENFST)\src\include\;C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
@@ -155,13 +156,14 @@
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;HAVE_CLAPACK;NO_PTHREAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <AdditionalIncludeDirectories>$(OPENFST)\src\include;C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">

--- a/kaldi_clapack_arm/kaldiwin/kaldi-kws/kaldi-kws.vcxproj
+++ b/kaldi_clapack_arm/kaldiwin/kaldi-kws/kaldi-kws.vcxproj
@@ -115,7 +115,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;HAVE_CLAPACK;NO_PTHREAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
@@ -123,6 +123,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+      <AdditionalIncludeDirectories>$(OPENFST)\src\include\;C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
@@ -155,13 +156,14 @@
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;HAVE_CLAPACK;NO_PTHREAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <AdditionalIncludeDirectories>$(OPENFST)\src\include;C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">

--- a/kaldi_clapack_arm/kaldiwin/kaldi-kws/kaldi-kws.vcxproj
+++ b/kaldi_clapack_arm/kaldiwin/kaldi-kws/kaldi-kws.vcxproj
@@ -95,8 +95,7 @@
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'" Label="PropertySheets">
     <Import Project="..\variables.props" />
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-    <Import Project="..\kaldiwin_win32.props" />
-    <Import Project="..\openfstwin_release_win32.props" />
+    <Import Project="..\kaldiwin_arm.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
     <Import Project="..\variables.props" />
@@ -115,7 +114,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;HAVE_CLAPACK;NO_PTHREAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
@@ -123,7 +122,6 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
-      <AdditionalIncludeDirectories>$(OPENFST)\src\include\;C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
@@ -156,28 +154,25 @@
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;HAVE_CLAPACK;NO_PTHREAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <AdditionalIncludeDirectories>$(OPENFST)\src\include;C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WINDOWS_ARM;HAVE_CLAPACK;_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <AdditionalIncludeDirectories>../../../tools/openfst/src/include/;../../../tools/CLAPACK/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">

--- a/kaldi_clapack_arm/kaldiwin/kaldi-lat/kaldi-lat.vcxproj
+++ b/kaldi_clapack_arm/kaldiwin/kaldi-lat/kaldi-lat.vcxproj
@@ -95,8 +95,7 @@
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'" Label="PropertySheets">
     <Import Project="..\variables.props" />
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-    <Import Project="..\kaldiwin_win32.props" />
-    <Import Project="..\openfstwin_release_win32.props" />
+    <Import Project="..\kaldiwin_arm.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
     <Import Project="..\variables.props" />
@@ -115,7 +114,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;HAVE_CLAPACK;NO_PTHREAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
@@ -123,7 +122,6 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
-      <AdditionalIncludeDirectories>$(OPENFST)\src\include\;C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
@@ -156,28 +154,25 @@
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;HAVE_CLAPACK;NO_PTHREAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <AdditionalIncludeDirectories>$(OPENFST)\src\include;C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WINDOWS_ARM;HAVE_CLAPACK;_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <AdditionalIncludeDirectories>../../../tools/CLAPACK/;../../../tools/openfst/src/include/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">

--- a/kaldi_clapack_arm/kaldiwin/kaldi-lat/kaldi-lat.vcxproj
+++ b/kaldi_clapack_arm/kaldiwin/kaldi-lat/kaldi-lat.vcxproj
@@ -115,7 +115,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;HAVE_CLAPACK;NO_PTHREAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
@@ -123,6 +123,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+      <AdditionalIncludeDirectories>$(OPENFST)\src\include\;C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
@@ -155,13 +156,14 @@
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;HAVE_CLAPACK;NO_PTHREAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <AdditionalIncludeDirectories>$(OPENFST)\src\include;C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">

--- a/kaldi_clapack_arm/kaldiwin/kaldi-matrix/kaldi-matrix.vcxproj
+++ b/kaldi_clapack_arm/kaldiwin/kaldi-matrix/kaldi-matrix.vcxproj
@@ -115,7 +115,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;HAVE_CLAPACK;NO_PTHREAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
@@ -123,6 +123,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+      <AdditionalIncludeDirectories>$(OPENFST)\src\include\;C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
@@ -155,14 +156,18 @@
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;HAVE_CLAPACK;NO_PTHREAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <AdditionalIncludeDirectories>$(OPENFST)\src\include;C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
+    <Lib>
+      <AdditionalLibraryDirectories>C:\opt\local\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+    </Lib>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
     <ClCompile>
@@ -175,8 +180,12 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <AdditionalIncludeDirectories>../../../tools/CLAPACK/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <CompileAs>CompileAsCpp</CompileAs>
     </ClCompile>
+    <Lib>
+      <AdditionalLibraryDirectories>C:\opt\arm\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+    </Lib>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>

--- a/kaldi_clapack_arm/kaldiwin/kaldi-matrix/kaldi-matrix.vcxproj
+++ b/kaldi_clapack_arm/kaldiwin/kaldi-matrix/kaldi-matrix.vcxproj
@@ -95,8 +95,7 @@
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'" Label="PropertySheets">
     <Import Project="..\variables.props" />
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-    <Import Project="..\kaldiwin_win32.props" />
-    <Import Project="..\openfstwin_release_win32.props" />
+    <Import Project="..\kaldiwin_arm.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
     <Import Project="..\variables.props" />
@@ -115,7 +114,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;HAVE_CLAPACK;NO_PTHREAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
@@ -123,7 +122,6 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
-      <AdditionalIncludeDirectories>$(OPENFST)\src\include\;C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
@@ -156,18 +154,14 @@
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;HAVE_CLAPACK;NO_PTHREAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <AdditionalIncludeDirectories>$(OPENFST)\src\include;C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
-    <Lib>
-      <AdditionalLibraryDirectories>C:\opt\local\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-    </Lib>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
     <ClCompile>
@@ -180,12 +174,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <AdditionalIncludeDirectories>C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <CompileAs>CompileAsCpp</CompileAs>
     </ClCompile>
-    <Lib>
-      <AdditionalLibraryDirectories>C:\opt\arm\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-    </Lib>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
@@ -210,6 +199,7 @@
     <ClCompile Include="..\..\..\src\matrix\packed-matrix.cc" />
     <ClCompile Include="..\..\..\src\matrix\qr.cc" />
     <ClCompile Include="..\..\..\src\matrix\sp-matrix.cc" />
+    <ClCompile Include="..\..\..\src\matrix\sparse-matrix.cc" />
     <ClCompile Include="..\..\..\src\matrix\srfft.cc" />
     <ClCompile Include="..\..\..\src\matrix\tp-matrix.cc" />
   </ItemGroup>
@@ -226,6 +216,7 @@
     <ClInclude Include="..\..\..\src\matrix\packed-matrix.h" />
     <ClInclude Include="..\..\..\src\matrix\sp-matrix-inl.h" />
     <ClInclude Include="..\..\..\src\matrix\sp-matrix.h" />
+    <ClInclude Include="..\..\..\src\matrix\sparse-matrix.h" />
     <ClInclude Include="..\..\..\src\matrix\srfft.h" />
     <ClInclude Include="..\..\..\src\matrix\tp-matrix.h" />
   </ItemGroup>

--- a/kaldi_clapack_arm/kaldiwin/kaldi-matrix/kaldi-matrix.vcxproj.filters
+++ b/kaldi_clapack_arm/kaldiwin/kaldi-matrix/kaldi-matrix.vcxproj.filters
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="Source Files">

--- a/kaldi_clapack_arm/kaldiwin/kaldi-matrix/kaldi-matrix.vcxproj.filters
+++ b/kaldi_clapack_arm/kaldiwin/kaldi-matrix/kaldi-matrix.vcxproj.filters
@@ -52,6 +52,9 @@
     <ClCompile Include="..\..\..\src\matrix\tp-matrix.cc">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\src\matrix\sparse-matrix.cc">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\src\matrix\compressed-matrix.h">
@@ -94,6 +97,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\src\matrix\tp-matrix.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\src\matrix\sparse-matrix.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/kaldi_clapack_arm/kaldiwin/kaldi-nnet/kaldi-nnet.vcxproj
+++ b/kaldi_clapack_arm/kaldiwin/kaldi-nnet/kaldi-nnet.vcxproj
@@ -115,7 +115,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;HAVE_CLAPACK;NO_PTHREAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
@@ -123,6 +123,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+      <AdditionalIncludeDirectories>$(OPENFST)\src\include\;C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
@@ -155,13 +156,14 @@
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;HAVE_CLAPACK;NO_PTHREAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <AdditionalIncludeDirectories>$(OPENFST)\src\include;C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">

--- a/kaldi_clapack_arm/kaldiwin/kaldi-nnet/kaldi-nnet.vcxproj
+++ b/kaldi_clapack_arm/kaldiwin/kaldi-nnet/kaldi-nnet.vcxproj
@@ -95,8 +95,7 @@
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'" Label="PropertySheets">
     <Import Project="..\variables.props" />
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-    <Import Project="..\kaldiwin_win32.props" />
-    <Import Project="..\openfstwin_release_win32.props" />
+    <Import Project="..\kaldiwin_arm.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
     <Import Project="..\variables.props" />
@@ -115,7 +114,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;HAVE_CLAPACK;NO_PTHREAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
@@ -123,7 +122,6 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
-      <AdditionalIncludeDirectories>$(OPENFST)\src\include\;C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
@@ -156,28 +154,25 @@
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;HAVE_CLAPACK;NO_PTHREAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <AdditionalIncludeDirectories>$(OPENFST)\src\include;C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WINDOWS_ARM;HAVE_CLAPACK;_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <AdditionalIncludeDirectories>../../../tools/openfst/src/include/;../../../tools/CLAPACK/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">

--- a/kaldi_clapack_arm/kaldiwin/kaldi-nnet2/kaldi-nnet2.vcxproj
+++ b/kaldi_clapack_arm/kaldiwin/kaldi-nnet2/kaldi-nnet2.vcxproj
@@ -95,8 +95,7 @@
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'" Label="PropertySheets">
     <Import Project="..\variables.props" />
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-    <Import Project="..\kaldiwin_win32.props" />
-    <Import Project="..\openfstwin_release_win32.props" />
+    <Import Project="..\kaldiwin_arm.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
     <Import Project="..\variables.props" />
@@ -115,7 +114,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;HAVE_CLAPACK;NO_PTHREAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
@@ -123,7 +122,6 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
-      <AdditionalIncludeDirectories>$(OPENFST)\src\include\;C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
@@ -156,28 +154,25 @@
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;HAVE_CLAPACK;NO_PTHREAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <AdditionalIncludeDirectories>$(OPENFST)\src\include;C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WINDOWS_ARM;HAVE_CLAPACK;_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE;NO_PTHREAD</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <AdditionalIncludeDirectories>../../../tools/openfst/src/include/;../../../../pthreads-w32/pthreads.2/;../../../tools/CLAPACK/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -219,7 +214,6 @@
     <ClCompile Include="..\..\..\src\nnet2\online-nnet2-decodable.cc" />
     <ClCompile Include="..\..\..\src\nnet2\rescale-nnet.cc" />
     <ClCompile Include="..\..\..\src\nnet2\shrink-nnet.cc" />
-    <ClCompile Include="..\..\..\src\nnet2\train-nnet-ensemble.cc" />
     <ClCompile Include="..\..\..\src\nnet2\widen-nnet.cc" />
   </ItemGroup>
   <ItemGroup>

--- a/kaldi_clapack_arm/kaldiwin/kaldi-nnet2/kaldi-nnet2.vcxproj
+++ b/kaldi_clapack_arm/kaldiwin/kaldi-nnet2/kaldi-nnet2.vcxproj
@@ -115,7 +115,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;HAVE_CLAPACK;NO_PTHREAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
@@ -123,6 +123,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+      <AdditionalIncludeDirectories>$(OPENFST)\src\include\;C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
@@ -155,20 +156,21 @@
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;HAVE_CLAPACK;NO_PTHREAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <AdditionalIncludeDirectories>$(OPENFST)\src\include;C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WINDOWS_ARM;HAVE_CLAPACK;_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WINDOWS_ARM;HAVE_CLAPACK;_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE;NO_PTHREAD</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>
@@ -218,8 +220,6 @@
     <ClCompile Include="..\..\..\src\nnet2\rescale-nnet.cc" />
     <ClCompile Include="..\..\..\src\nnet2\shrink-nnet.cc" />
     <ClCompile Include="..\..\..\src\nnet2\train-nnet-ensemble.cc" />
-    <ClCompile Include="..\..\..\src\nnet2\train-nnet-perturbed.cc" />
-    <ClCompile Include="..\..\..\src\nnet2\train-nnet.cc" />
     <ClCompile Include="..\..\..\src\nnet2\widen-nnet.cc" />
   </ItemGroup>
   <ItemGroup>

--- a/kaldi_clapack_arm/kaldiwin/kaldi-nnet2/kaldi-nnet2.vcxproj.filters
+++ b/kaldi_clapack_arm/kaldiwin/kaldi-nnet2/kaldi-nnet2.vcxproj.filters
@@ -94,9 +94,6 @@
     <ClCompile Include="..\..\..\src\nnet2\shrink-nnet.cc">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\src\nnet2\train-nnet-ensemble.cc">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\..\src\nnet2\widen-nnet.cc">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/kaldi_clapack_arm/kaldiwin/kaldi-nnet2/kaldi-nnet2.vcxproj.filters
+++ b/kaldi_clapack_arm/kaldiwin/kaldi-nnet2/kaldi-nnet2.vcxproj.filters
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="Source Files">
@@ -95,12 +95,6 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\src\nnet2\train-nnet-ensemble.cc">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\src\nnet2\train-nnet-perturbed.cc">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\src\nnet2\train-nnet.cc">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\src\nnet2\widen-nnet.cc">

--- a/kaldi_clapack_arm/kaldiwin/kaldi-online/kaldi-online.vcxproj
+++ b/kaldi_clapack_arm/kaldiwin/kaldi-online/kaldi-online.vcxproj
@@ -115,7 +115,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;HAVE_CLAPACK;NO_PTHREAD;KALDI_NO_PORTAUDIO;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
@@ -123,6 +123,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+      <AdditionalIncludeDirectories>$(OPENFST)\src\include\;C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
@@ -155,13 +156,14 @@
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;KALDI_NO_PORTAUDIO;NDEBUG;_LIB;HAVE_CLAPACK;NO_PTHREAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <AdditionalIncludeDirectories>$(OPENFST)\src\include;C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">

--- a/kaldi_clapack_arm/kaldiwin/kaldi-online/kaldi-online.vcxproj
+++ b/kaldi_clapack_arm/kaldiwin/kaldi-online/kaldi-online.vcxproj
@@ -95,8 +95,7 @@
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'" Label="PropertySheets">
     <Import Project="..\variables.props" />
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-    <Import Project="..\kaldiwin_win32.props" />
-    <Import Project="..\openfstwin_release_win32.props" />
+    <Import Project="..\kaldiwin_arm.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
     <Import Project="..\variables.props" />
@@ -115,7 +114,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;HAVE_CLAPACK;NO_PTHREAD;KALDI_NO_PORTAUDIO;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
@@ -123,7 +122,6 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
-      <AdditionalIncludeDirectories>$(OPENFST)\src\include\;C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
@@ -156,28 +154,26 @@
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;KALDI_NO_PORTAUDIO;NDEBUG;_LIB;HAVE_CLAPACK;NO_PTHREAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <AdditionalIncludeDirectories>$(OPENFST)\src\include;C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WINDOWS_ARM;KALDI_NO_PORTAUDIO;HAVE_CLAPACK;_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <AdditionalIncludeDirectories>../../../tools/openfst/src/include/;../../../tools/CLAPACK/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>KALDI_NO_PORTAUDIO;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">

--- a/kaldi_clapack_arm/kaldiwin/kaldi-online2/kaldi-online2.vcxproj
+++ b/kaldi_clapack_arm/kaldiwin/kaldi-online2/kaldi-online2.vcxproj
@@ -95,8 +95,7 @@
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'" Label="PropertySheets">
     <Import Project="..\variables.props" />
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-    <Import Project="..\kaldiwin_win32.props" />
-    <Import Project="..\openfstwin_release_win32.props" />
+    <Import Project="..\kaldiwin_arm.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
     <Import Project="..\variables.props" />
@@ -115,7 +114,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;HAVE_CLAPACK;NO_PTHREAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
@@ -123,7 +122,6 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
-      <AdditionalIncludeDirectories>$(OPENFST)\src\include\;C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
@@ -156,28 +154,25 @@
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;HAVE_CLAPACK;NO_PTHREAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <AdditionalIncludeDirectories>$(OPENFST)\src\include;C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WINDOWS_ARM;HAVE_CLAPACK;_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE;NO_PTHREAD</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <AdditionalIncludeDirectories>../../../../pthreads-w32/pthreads.2/;../../../tools/openfst/src/include/;../../../tools/CLAPACK/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">

--- a/kaldi_clapack_arm/kaldiwin/kaldi-online2/kaldi-online2.vcxproj
+++ b/kaldi_clapack_arm/kaldiwin/kaldi-online2/kaldi-online2.vcxproj
@@ -115,7 +115,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;HAVE_CLAPACK;NO_PTHREAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
@@ -123,6 +123,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+      <AdditionalIncludeDirectories>$(OPENFST)\src\include\;C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
@@ -155,20 +156,21 @@
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;HAVE_CLAPACK;NO_PTHREAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <AdditionalIncludeDirectories>$(OPENFST)\src\include;C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WINDOWS_ARM;HAVE_CLAPACK;_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WINDOWS_ARM;HAVE_CLAPACK;_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE;NO_PTHREAD</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>
@@ -197,7 +199,6 @@
     <ClCompile Include="..\..\..\src\online2\online-gmm-decodable.cc" />
     <ClCompile Include="..\..\..\src\online2\online-gmm-decoding.cc" />
     <ClCompile Include="..\..\..\src\online2\online-ivector-feature.cc" />
-    <ClCompile Include="..\..\..\src\online2\online-nnet2-decoding-threaded.cc" />
     <ClCompile Include="..\..\..\src\online2\online-nnet2-decoding.cc" />
     <ClCompile Include="..\..\..\src\online2\online-nnet2-feature-pipeline.cc" />
     <ClCompile Include="..\..\..\src\online2\online-speex-wrapper.cc" />

--- a/kaldi_clapack_arm/kaldiwin/kaldi-online2/kaldi-online2.vcxproj.filters
+++ b/kaldi_clapack_arm/kaldiwin/kaldi-online2/kaldi-online2.vcxproj.filters
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="Source Files">
@@ -32,9 +32,6 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\src\online2\online-ivector-feature.cc">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\src\online2\online-nnet2-decoding-threaded.cc">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\src\online2\online-nnet2-decoding.cc">

--- a/kaldi_clapack_arm/kaldiwin/kaldi-sgmm/kaldi-sgmm.vcxproj
+++ b/kaldi_clapack_arm/kaldiwin/kaldi-sgmm/kaldi-sgmm.vcxproj
@@ -115,7 +115,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;HAVE_CLAPACK;NO_PTHREAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
@@ -123,6 +123,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+      <AdditionalIncludeDirectories>$(OPENFST)\src\include\;C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
@@ -155,20 +156,21 @@
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;HAVE_CLAPACK;NO_PTHREAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <AdditionalIncludeDirectories>$(OPENFST)\src\include;C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WINDOWS_ARM;HAVE_CLAPACK;_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WINDOWS_ARM;HAVE_CLAPACK;_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE;NO_PTHREAD</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>

--- a/kaldi_clapack_arm/kaldiwin/kaldi-sgmm/kaldi-sgmm.vcxproj
+++ b/kaldi_clapack_arm/kaldiwin/kaldi-sgmm/kaldi-sgmm.vcxproj
@@ -95,8 +95,7 @@
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'" Label="PropertySheets">
     <Import Project="..\variables.props" />
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-    <Import Project="..\kaldiwin_win32.props" />
-    <Import Project="..\openfstwin_release_win32.props" />
+    <Import Project="..\kaldiwin_arm.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
     <Import Project="..\variables.props" />
@@ -115,7 +114,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;HAVE_CLAPACK;NO_PTHREAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
@@ -123,7 +122,6 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
-      <AdditionalIncludeDirectories>$(OPENFST)\src\include\;C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
@@ -156,28 +154,25 @@
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;HAVE_CLAPACK;NO_PTHREAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <AdditionalIncludeDirectories>$(OPENFST)\src\include;C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WINDOWS_ARM;HAVE_CLAPACK;_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE;NO_PTHREAD</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <AdditionalIncludeDirectories>../../../tools/openfst/src/include/;../../../../pthreads-w32/pthreads.2/;../../../tools/CLAPACK/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">

--- a/kaldi_clapack_arm/kaldiwin/kaldi-sgmm2/kaldi-sgmm2.vcxproj
+++ b/kaldi_clapack_arm/kaldiwin/kaldi-sgmm2/kaldi-sgmm2.vcxproj
@@ -115,7 +115,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;HAVE_CLAPACK;NO_PTHREAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
@@ -123,6 +123,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+      <AdditionalIncludeDirectories>$(OPENFST)\src\include\;C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
@@ -155,20 +156,21 @@
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;HAVE_CLAPACK;NO_PTHREAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <AdditionalIncludeDirectories>$(OPENFST)\src\include;C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WINDOWS_ARM;HAVE_CLAPACK;_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WINDOWS_ARM;HAVE_CLAPACK;_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE;NO_PTHREAD</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>

--- a/kaldi_clapack_arm/kaldiwin/kaldi-sgmm2/kaldi-sgmm2.vcxproj
+++ b/kaldi_clapack_arm/kaldiwin/kaldi-sgmm2/kaldi-sgmm2.vcxproj
@@ -95,8 +95,7 @@
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'" Label="PropertySheets">
     <Import Project="..\variables.props" />
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-    <Import Project="..\kaldiwin_win32.props" />
-    <Import Project="..\openfstwin_release_win32.props" />
+    <Import Project="..\kaldiwin_arm.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
     <Import Project="..\variables.props" />
@@ -115,7 +114,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;HAVE_CLAPACK;NO_PTHREAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
@@ -123,7 +122,6 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
-      <AdditionalIncludeDirectories>$(OPENFST)\src\include\;C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
@@ -156,28 +154,25 @@
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;HAVE_CLAPACK;NO_PTHREAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <AdditionalIncludeDirectories>$(OPENFST)\src\include;C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WINDOWS_ARM;HAVE_CLAPACK;_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE;NO_PTHREAD</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <AdditionalIncludeDirectories>../../../../pthreads-w32/pthreads.2/;../../../tools/openfst/src/include/;../../../tools/CLAPACK/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">

--- a/kaldi_clapack_arm/kaldiwin/kaldi-thread/kaldi-thread.vcxproj
+++ b/kaldi_clapack_arm/kaldiwin/kaldi-thread/kaldi-thread.vcxproj
@@ -95,8 +95,7 @@
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'" Label="PropertySheets">
     <Import Project="..\variables.props" />
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-    <Import Project="..\kaldiwin_win32.props" />
-    <Import Project="..\openfstwin_release_win32.props" />
+    <Import Project="..\kaldiwin_arm.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
     <Import Project="..\variables.props" />
@@ -155,28 +154,25 @@
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;HAVE_CLAPACK;NO_PTHREAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <AdditionalIncludeDirectories>$(OPENFST)\src\include;C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WINDOWS_ARM;HAVE_CLAPACK;_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE;NO_PTHREAD</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <AdditionalIncludeDirectories>../../../../pthreads-w32/pthreads.2/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -193,8 +189,6 @@
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="..\..\..\src\thread\kaldi-barrier.cc" />
-    <ClCompile Include="..\..\..\src\thread\kaldi-mutex.cc" />
     <ClCompile Include="..\..\..\src\thread\kaldi-thread.cc" />
   </ItemGroup>
   <ItemGroup>

--- a/kaldi_clapack_arm/kaldiwin/kaldi-thread/kaldi-thread.vcxproj
+++ b/kaldi_clapack_arm/kaldiwin/kaldi-thread/kaldi-thread.vcxproj
@@ -155,20 +155,21 @@
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;HAVE_CLAPACK;NO_PTHREAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <AdditionalIncludeDirectories>$(OPENFST)\src\include;C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WINDOWS_ARM;HAVE_CLAPACK;_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WINDOWS_ARM;HAVE_CLAPACK;_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE;NO_PTHREAD</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>
@@ -194,7 +195,6 @@
   <ItemGroup>
     <ClCompile Include="..\..\..\src\thread\kaldi-barrier.cc" />
     <ClCompile Include="..\..\..\src\thread\kaldi-mutex.cc" />
-    <ClCompile Include="..\..\..\src\thread\kaldi-semaphore.cc" />
     <ClCompile Include="..\..\..\src\thread\kaldi-thread.cc" />
   </ItemGroup>
   <ItemGroup>

--- a/kaldi_clapack_arm/kaldiwin/kaldi-thread/kaldi-thread.vcxproj.filters
+++ b/kaldi_clapack_arm/kaldiwin/kaldi-thread/kaldi-thread.vcxproj.filters
@@ -19,12 +19,6 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="..\..\..\src\thread\kaldi-barrier.cc">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\src\thread\kaldi-mutex.cc">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\..\src\thread\kaldi-thread.cc">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/kaldi_clapack_arm/kaldiwin/kaldi-thread/kaldi-thread.vcxproj.filters
+++ b/kaldi_clapack_arm/kaldiwin/kaldi-thread/kaldi-thread.vcxproj.filters
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="Source Files">
@@ -23,9 +23,6 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\src\thread\kaldi-mutex.cc">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\src\thread\kaldi-semaphore.cc">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\src\thread\kaldi-thread.cc">

--- a/kaldi_clapack_arm/kaldiwin/kaldi-transform/kaldi-transform.vcxproj
+++ b/kaldi_clapack_arm/kaldiwin/kaldi-transform/kaldi-transform.vcxproj
@@ -95,8 +95,7 @@
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'" Label="PropertySheets">
     <Import Project="..\variables.props" />
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-    <Import Project="..\kaldiwin_win32.props" />
-    <Import Project="..\openfstwin_release_win32.props" />
+    <Import Project="..\kaldiwin_arm.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
     <Import Project="..\variables.props" />
@@ -115,7 +114,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;HAVE_CLAPACK;NO_PTHREAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
@@ -123,7 +122,6 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
-      <AdditionalIncludeDirectories>$(OPENFST)\src\include\;C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
@@ -156,28 +154,25 @@
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;HAVE_CLAPACK;NO_PTHREAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <AdditionalIncludeDirectories>$(OPENFST)\src\include;C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WINDOWS_ARM;HAVE_CLAPACK;_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <AdditionalIncludeDirectories>../../../tools/CLAPACK/;../../../tools/openfst/src/include/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">

--- a/kaldi_clapack_arm/kaldiwin/kaldi-transform/kaldi-transform.vcxproj
+++ b/kaldi_clapack_arm/kaldiwin/kaldi-transform/kaldi-transform.vcxproj
@@ -115,7 +115,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;HAVE_CLAPACK;NO_PTHREAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
@@ -123,6 +123,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+      <AdditionalIncludeDirectories>$(OPENFST)\src\include\;C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
@@ -155,13 +156,14 @@
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;HAVE_CLAPACK;NO_PTHREAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <AdditionalIncludeDirectories>$(OPENFST)\src\include;C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">

--- a/kaldi_clapack_arm/kaldiwin/kaldi-tree/kaldi-tree.vcxproj
+++ b/kaldi_clapack_arm/kaldiwin/kaldi-tree/kaldi-tree.vcxproj
@@ -115,7 +115,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;HAVE_CLAPACK;NO_PTHREAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
@@ -123,6 +123,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+      <AdditionalIncludeDirectories>$(OPENFST)\src\include\;C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
@@ -155,13 +156,14 @@
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;HAVE_CLAPACK;NO_PTHREAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <AdditionalIncludeDirectories>$(OPENFST)\src\include;C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">

--- a/kaldi_clapack_arm/kaldiwin/kaldi-tree/kaldi-tree.vcxproj
+++ b/kaldi_clapack_arm/kaldiwin/kaldi-tree/kaldi-tree.vcxproj
@@ -95,8 +95,7 @@
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'" Label="PropertySheets">
     <Import Project="..\variables.props" />
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-    <Import Project="..\kaldiwin_win32.props" />
-    <Import Project="..\openfstwin_release_win32.props" />
+    <Import Project="..\kaldiwin_arm.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
     <Import Project="..\variables.props" />
@@ -115,7 +114,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;HAVE_CLAPACK;NO_PTHREAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
@@ -123,7 +122,6 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
-      <AdditionalIncludeDirectories>$(OPENFST)\src\include\;C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
@@ -156,28 +154,25 @@
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;HAVE_CLAPACK;NO_PTHREAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <AdditionalIncludeDirectories>$(OPENFST)\src\include;C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WINDOWS_ARM;HAVE_CLAPACK;_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <AdditionalIncludeDirectories>../../../tools/openfst/src/include/;../../../tools/CLAPACK/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">

--- a/kaldi_clapack_arm/kaldiwin/kaldi-util/kaldi-util.vcxproj
+++ b/kaldi_clapack_arm/kaldiwin/kaldi-util/kaldi-util.vcxproj
@@ -95,8 +95,7 @@
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'" Label="PropertySheets">
     <Import Project="..\variables.props" />
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-    <Import Project="..\kaldiwin_win32.props" />
-    <Import Project="..\openfstwin_release_win32.props" />
+    <Import Project="..\kaldiwin_arm.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
     <Import Project="..\variables.props" />
@@ -115,7 +114,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;HAVE_CLAPACK;NO_PTHREAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
@@ -123,7 +122,6 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
-      <AdditionalIncludeDirectories>$(OPENFST)\src\include\;C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
@@ -156,28 +154,25 @@
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;HAVE_CLAPACK;NO_PTHREAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <AdditionalIncludeDirectories>$(OPENFST)\src\include;C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WINDOWS_ARM;HAVE_CLAPACK;_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <AdditionalIncludeDirectories>../../../tools/CLAPACK/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">

--- a/kaldi_clapack_arm/kaldiwin/kaldi-util/kaldi-util.vcxproj
+++ b/kaldi_clapack_arm/kaldiwin/kaldi-util/kaldi-util.vcxproj
@@ -115,7 +115,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;HAVE_CLAPACK;NO_PTHREAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
@@ -123,6 +123,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+      <AdditionalIncludeDirectories>$(OPENFST)\src\include\;C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
@@ -155,13 +156,14 @@
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;HAVE_CLAPACK;NO_PTHREAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <AdditionalIncludeDirectories>$(OPENFST)\src\include;C:\opt\local\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">

--- a/kaldi_clapack_arm/kaldiwin/kaldiwin_arm.props
+++ b/kaldi_clapack_arm/kaldiwin/kaldiwin_arm.props
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
+    <LinkIncremental>
+    </LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <AdditionalOptions>/bigobj  %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalIncludeDirectories>c:\opt\arm\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>HAVE_CLAPACK;HAVE_LAPACK_CONFIG_H;LAPACK_COMPLEX_STRUCTURE;USE_ONLY_PRERECORDED;NO_PTHREAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <AdditionalLibraryDirectories>c:\opt\arm\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+</Project>

--- a/kaldi_clapack_arm/kaldiwin/online2-wav-nnet2-latgen-faster/online2-wav-nnet2-latgen-faster.vcxproj
+++ b/kaldi_clapack_arm/kaldiwin/online2-wav-nnet2-latgen-faster/online2-wav-nnet2-latgen-faster.vcxproj
@@ -101,8 +101,7 @@
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'" Label="PropertySheets">
     <Import Project="..\variables.props" />
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-    <Import Project="..\kaldiwin_win32.props" />
-    <Import Project="..\openfstwin_release_win32.props" />
+    <Import Project="..\kaldiwin_arm.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
     <Import Project="..\variables.props" />
@@ -195,7 +194,6 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WINDOWS_ARM;KALDI_NO_PORTAUDIO;HAVE_CLAPACK;_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>../../../../pthreads-w32/pthreads.2/;../../../tools/openfst/src/include/;../../../tools/CLAPACK/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>

--- a/kaldi_clapack_arm/kaldiwin_vs2013.sln
+++ b/kaldi_clapack_arm/kaldiwin_vs2013.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.24720.0
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "kaldi-base", "kaldiwin\kaldi-base\kaldi-base.vcxproj", "{4E0D73AB-D3ED-41D9-918D-1EB8EB3A8670}"
 EndProject
@@ -36,15 +36,11 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "kaldi-sgmm", "kaldiwin\kald
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "kaldi-sgmm2", "kaldiwin\kaldi-sgmm2\kaldi-sgmm2.vcxproj", "{C3C1E4BE-EF86-49DC-9E9A-3DD961EECC63}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "kaldi-thread", "kaldiwin\kaldi-thread\kaldi-thread.vcxproj", "{7B5F0314-69C4-4F93-8514-6E732ED36340}"
-EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "kaldi-transform", "kaldiwin\kaldi-transform\kaldi-transform.vcxproj", "{FDD563C4-7BF9-4CBD-A55D-E1D7D25E6D3C}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "kaldi-tree", "kaldiwin\kaldi-tree\kaldi-tree.vcxproj", "{A6223446-31E7-46B9-A960-A6390AD566B5}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "kaldi-util", "kaldiwin\kaldi-util\kaldi-util.vcxproj", "{0E30D283-D63E-42CC-9B0B-8C28F2B66FC2}"
-EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "online2-wav-nnet2-latgen-faster", "kaldiwin\online2-wav-nnet2-latgen-faster\online2-wav-nnet2-latgen-faster.vcxproj", "{C1ED2AED-7B4C-4289-AB6C-C944EDACC099}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -260,18 +256,6 @@ Global
 		{C3C1E4BE-EF86-49DC-9E9A-3DD961EECC63}.Release|Win32.Build.0 = Release|Win32
 		{C3C1E4BE-EF86-49DC-9E9A-3DD961EECC63}.Release|x64.ActiveCfg = Release|x64
 		{C3C1E4BE-EF86-49DC-9E9A-3DD961EECC63}.Release|x64.Build.0 = Release|x64
-		{7B5F0314-69C4-4F93-8514-6E732ED36340}.Debug|ARM.ActiveCfg = Debug|ARM
-		{7B5F0314-69C4-4F93-8514-6E732ED36340}.Debug|ARM.Build.0 = Debug|ARM
-		{7B5F0314-69C4-4F93-8514-6E732ED36340}.Debug|Win32.ActiveCfg = Debug|Win32
-		{7B5F0314-69C4-4F93-8514-6E732ED36340}.Debug|Win32.Build.0 = Debug|Win32
-		{7B5F0314-69C4-4F93-8514-6E732ED36340}.Debug|x64.ActiveCfg = Debug|x64
-		{7B5F0314-69C4-4F93-8514-6E732ED36340}.Debug|x64.Build.0 = Debug|x64
-		{7B5F0314-69C4-4F93-8514-6E732ED36340}.Release|ARM.ActiveCfg = Release|ARM
-		{7B5F0314-69C4-4F93-8514-6E732ED36340}.Release|ARM.Build.0 = Release|ARM
-		{7B5F0314-69C4-4F93-8514-6E732ED36340}.Release|Win32.ActiveCfg = Release|Win32
-		{7B5F0314-69C4-4F93-8514-6E732ED36340}.Release|Win32.Build.0 = Release|Win32
-		{7B5F0314-69C4-4F93-8514-6E732ED36340}.Release|x64.ActiveCfg = Release|x64
-		{7B5F0314-69C4-4F93-8514-6E732ED36340}.Release|x64.Build.0 = Release|x64
 		{FDD563C4-7BF9-4CBD-A55D-E1D7D25E6D3C}.Debug|ARM.ActiveCfg = Debug|ARM
 		{FDD563C4-7BF9-4CBD-A55D-E1D7D25E6D3C}.Debug|ARM.Build.0 = Debug|ARM
 		{FDD563C4-7BF9-4CBD-A55D-E1D7D25E6D3C}.Debug|Win32.ActiveCfg = Debug|Win32
@@ -308,17 +292,6 @@ Global
 		{0E30D283-D63E-42CC-9B0B-8C28F2B66FC2}.Release|Win32.Build.0 = Release|Win32
 		{0E30D283-D63E-42CC-9B0B-8C28F2B66FC2}.Release|x64.ActiveCfg = Release|x64
 		{0E30D283-D63E-42CC-9B0B-8C28F2B66FC2}.Release|x64.Build.0 = Release|x64
-		{C1ED2AED-7B4C-4289-AB6C-C944EDACC099}.Debug|ARM.ActiveCfg = Debug|Win32
-		{C1ED2AED-7B4C-4289-AB6C-C944EDACC099}.Debug|Win32.ActiveCfg = Debug|Win32
-		{C1ED2AED-7B4C-4289-AB6C-C944EDACC099}.Debug|Win32.Build.0 = Debug|Win32
-		{C1ED2AED-7B4C-4289-AB6C-C944EDACC099}.Debug|x64.ActiveCfg = Debug|x64
-		{C1ED2AED-7B4C-4289-AB6C-C944EDACC099}.Debug|x64.Build.0 = Debug|x64
-		{C1ED2AED-7B4C-4289-AB6C-C944EDACC099}.Release|ARM.ActiveCfg = Release|ARM
-		{C1ED2AED-7B4C-4289-AB6C-C944EDACC099}.Release|ARM.Build.0 = Release|ARM
-		{C1ED2AED-7B4C-4289-AB6C-C944EDACC099}.Release|Win32.ActiveCfg = Release|Win32
-		{C1ED2AED-7B4C-4289-AB6C-C944EDACC099}.Release|Win32.Build.0 = Release|Win32
-		{C1ED2AED-7B4C-4289-AB6C-C944EDACC099}.Release|x64.ActiveCfg = Release|x64
-		{C1ED2AED-7B4C-4289-AB6C-C944EDACC099}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/kaldi_clapack_arm/kaldiwin_vs2013.sln
+++ b/kaldi_clapack_arm/kaldiwin_vs2013.sln
@@ -36,6 +36,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "kaldi-sgmm", "kaldiwin\kald
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "kaldi-sgmm2", "kaldiwin\kaldi-sgmm2\kaldi-sgmm2.vcxproj", "{C3C1E4BE-EF86-49DC-9E9A-3DD961EECC63}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "kaldi-thread", "kaldiwin\kaldi-thread\kaldi-thread.vcxproj", "{7B5F0314-69C4-4F93-8514-6E732ED36340}"
+EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "kaldi-transform", "kaldiwin\kaldi-transform\kaldi-transform.vcxproj", "{FDD563C4-7BF9-4CBD-A55D-E1D7D25E6D3C}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "kaldi-tree", "kaldiwin\kaldi-tree\kaldi-tree.vcxproj", "{A6223446-31E7-46B9-A960-A6390AD566B5}"
@@ -256,6 +258,18 @@ Global
 		{C3C1E4BE-EF86-49DC-9E9A-3DD961EECC63}.Release|Win32.Build.0 = Release|Win32
 		{C3C1E4BE-EF86-49DC-9E9A-3DD961EECC63}.Release|x64.ActiveCfg = Release|x64
 		{C3C1E4BE-EF86-49DC-9E9A-3DD961EECC63}.Release|x64.Build.0 = Release|x64
+		{7B5F0314-69C4-4F93-8514-6E732ED36340}.Debug|ARM.ActiveCfg = Debug|ARM
+		{7B5F0314-69C4-4F93-8514-6E732ED36340}.Debug|ARM.Build.0 = Debug|ARM
+		{7B5F0314-69C4-4F93-8514-6E732ED36340}.Debug|Win32.ActiveCfg = Debug|Win32
+		{7B5F0314-69C4-4F93-8514-6E732ED36340}.Debug|Win32.Build.0 = Debug|Win32
+		{7B5F0314-69C4-4F93-8514-6E732ED36340}.Debug|x64.ActiveCfg = Debug|x64
+		{7B5F0314-69C4-4F93-8514-6E732ED36340}.Debug|x64.Build.0 = Debug|x64
+		{7B5F0314-69C4-4F93-8514-6E732ED36340}.Release|ARM.ActiveCfg = Release|ARM
+		{7B5F0314-69C4-4F93-8514-6E732ED36340}.Release|ARM.Build.0 = Release|ARM
+		{7B5F0314-69C4-4F93-8514-6E732ED36340}.Release|Win32.ActiveCfg = Release|Win32
+		{7B5F0314-69C4-4F93-8514-6E732ED36340}.Release|Win32.Build.0 = Release|Win32
+		{7B5F0314-69C4-4F93-8514-6E732ED36340}.Release|x64.ActiveCfg = Release|x64
+		{7B5F0314-69C4-4F93-8514-6E732ED36340}.Release|x64.Build.0 = Release|x64
 		{FDD563C4-7BF9-4CBD-A55D-E1D7D25E6D3C}.Debug|ARM.ActiveCfg = Debug|ARM
 		{FDD563C4-7BF9-4CBD-A55D-E1D7D25E6D3C}.Debug|ARM.Build.0 = Debug|ARM
 		{FDD563C4-7BF9-4CBD-A55D-E1D7D25E6D3C}.Debug|Win32.ActiveCfg = Debug|Win32

--- a/src/matrix/cblas-wrappers.h
+++ b/src/matrix/cblas-wrappers.h
@@ -33,6 +33,7 @@
 namespace kaldi {
 
 #ifndef HAVE_CLAPACK
+
 	inline void cblas_Xcopy(const int N, const float *X, const int incX, float *Y,
 		const int incY) {
 		cblas_scopy(N, X, incX, Y, incY);
@@ -486,6 +487,7 @@ namespace kaldi {
 	}
 #endif
 #else  // esle HAVE_CLAPACK
+
 
 
 

--- a/src/matrix/cblas-wrappers.h
+++ b/src/matrix/cblas-wrappers.h
@@ -32,7 +32,7 @@
 
 namespace kaldi {
 
-#ifndef WINDOWS_ARM
+#ifndef HAVE_CLAPACK
 	inline void cblas_Xcopy(const int N, const float *X, const int incX, float *Y,
 		const int incY) {
 		cblas_scopy(N, X, incX, Y, incY);
@@ -485,7 +485,7 @@ namespace kaldi {
 		*result = clapack_dgetri(CblasColMajor, num_rows, Mdata, stride, pivot);
 	}
 #endif
-#else  // esle WINDOWS_ARM
+#else  // esle HAVE_CLAPACK
 
 
 

--- a/src/matrix/cblas-wrappers.h
+++ b/src/matrix/cblas-wrappers.h
@@ -32,481 +32,940 @@
 
 namespace kaldi {
 
+#ifndef WINDOWS_ARM
+	inline void cblas_Xcopy(const int N, const float *X, const int incX, float *Y,
+		const int incY) {
+		cblas_scopy(N, X, incX, Y, incY);
+	}
 
-inline void cblas_Xcopy(const int N, const float *X, const int incX, float *Y,
-                        const int incY) {
-  cblas_scopy(N, X, incX, Y, incY);
-}
-
-inline void cblas_Xcopy(const int N, const double *X, const int incX, double *Y,
-                        const int incY) {
-  cblas_dcopy(N, X, incX, Y, incY);
-}
-
-
-inline float cblas_Xasum(const int N, const float *X, const int incX) {
-  return cblas_sasum(N, X, incX);
-}
-
-inline double cblas_Xasum(const int N, const double *X, const int incX) {
-  return cblas_dasum(N, X, incX);
-}
-
-inline void cblas_Xrot(const int N, float *X, const int incX, float *Y,
-                       const int incY, const float c, const float s) {
-  cblas_srot(N, X, incX, Y, incY, c, s);
-}
-inline void cblas_Xrot(const int N, double *X, const int incX, double *Y,
-                       const int incY, const double c, const double s) {
-  cblas_drot(N, X, incX, Y, incY, c, s);
-}
-inline float cblas_Xdot(const int N, const float *const X,
-                        const int incX, const float *const Y,
-                        const int incY) {
-// We have not been able to compile BLAS packages on windows for ARM.
-// So we replace cblas sdot with calls to CLAPACK.
-#ifdef WINDOWS_ARM
-  integer arg1 = N;
-  real arg2 = *X;
-  integer arg3 = incX;
-  real arg4 = *Y;
-  integer arg5 = incY;
-  return sdot_(&arg1, &arg2, &arg3, &arg4, &arg5);
-#else
-  return cblas_sdot(N, X, incX, Y, incY);
-#endif
-}
-inline double cblas_Xdot(const int N, const double *const X,
-                        const int incX, const double *const Y,
-                        const int incY) {
-// We have not been able to compile BLAS packages on windows for ARM.
-// So we replace cblas sdot with calls to CLAPACK.
-#ifdef WINDOWS_ARM
-  integer arg1 = N;
-  real arg2 = *X;
-  integer arg3 = incX;
-  real arg4 = *Y;
-  integer arg5 = incY;
-  return sdot_(&arg1, &arg2, &arg3, &arg4, &arg5);
-#else
-  return cblas_ddot(N, X, incX, Y, incY);
-#endif
-}
-inline void cblas_Xaxpy(const int N, const float alpha, const float *X,
-                        const int incX, float *Y, const int incY) {
-  cblas_saxpy(N, alpha, X, incX, Y, incY);
-}
-inline void cblas_Xaxpy(const int N, const double alpha, const double *X,
-                        const int incX, double *Y, const int incY) {
-  cblas_daxpy(N, alpha, X, incX, Y, incY);
-}
-inline void cblas_Xscal(const int N, const float alpha, float *data,
-                        const int inc) {
-  cblas_sscal(N, alpha, data, inc);
-}
-inline void cblas_Xscal(const int N, const double alpha, double *data, 
-                        const int inc) {
-  cblas_dscal(N, alpha, data, inc);
-}
-inline void cblas_Xspmv(const float alpha, const int num_rows, const float *Mdata,
-                        const float *v, const int v_inc,
-                        const float beta, float *y, const int y_inc) {
-  cblas_sspmv(CblasRowMajor, CblasLower, num_rows, alpha, Mdata, v, v_inc, beta, y, y_inc);
-}
-inline void cblas_Xspmv(const double alpha, const int num_rows, const double *Mdata,
-                        const double *v, const int v_inc,
-                        const double beta, double *y, const int y_inc) {
-  cblas_dspmv(CblasRowMajor, CblasLower, num_rows, alpha, Mdata, v, v_inc, beta, y, y_inc);
-}
-inline void cblas_Xtpmv(MatrixTransposeType trans, const float *Mdata,
-                        const int num_rows, float *y, const int y_inc) {
-  cblas_stpmv(CblasRowMajor, CblasLower, static_cast<CBLAS_TRANSPOSE>(trans),
-              CblasNonUnit, num_rows, Mdata, y, y_inc);
-}
-inline void cblas_Xtpmv(MatrixTransposeType trans, const double *Mdata,
-                        const int num_rows, double *y, const int y_inc) {
-  cblas_dtpmv(CblasRowMajor, CblasLower, static_cast<CBLAS_TRANSPOSE>(trans),
-              CblasNonUnit, num_rows, Mdata, y, y_inc);
-}
+	inline void cblas_Xcopy(const int N, const double *X, const int incX, double *Y,
+		const int incY) {
+		cblas_dcopy(N, X, incX, Y, incY);
+	}
 
 
-inline void cblas_Xtpsv(MatrixTransposeType trans, const float *Mdata,
-                        const int num_rows, float *y, const int y_inc) {
-  cblas_stpsv(CblasRowMajor, CblasLower, static_cast<CBLAS_TRANSPOSE>(trans),
-              CblasNonUnit, num_rows, Mdata, y, y_inc);
-}
-inline void cblas_Xtpsv(MatrixTransposeType trans, const double *Mdata,
-                        const int num_rows, double *y, const int y_inc) {
-  cblas_dtpsv(CblasRowMajor, CblasLower, static_cast<CBLAS_TRANSPOSE>(trans),
-              CblasNonUnit, num_rows, Mdata, y, y_inc);
-}
+	inline float cblas_Xasum(const int N, const float *X, const int incX) {
+		return cblas_sasum(N, X, incX);
+	}
 
-// x = alpha * M * y + beta * x
-inline void cblas_Xspmv(MatrixIndexT dim, float alpha, const float *Mdata,
-                        const float *ydata, MatrixIndexT ystride,
-                        float beta, float *xdata, MatrixIndexT xstride) {
-  cblas_sspmv(CblasRowMajor, CblasLower, dim, alpha, Mdata,
-              ydata, ystride, beta, xdata, xstride);
-}
-inline void cblas_Xspmv(MatrixIndexT dim, double alpha, const double *Mdata,
-                        const double *ydata, MatrixIndexT ystride,
-                        double beta, double *xdata, MatrixIndexT xstride) {
-  cblas_dspmv(CblasRowMajor, CblasLower, dim, alpha, Mdata,
-              ydata, ystride, beta, xdata, xstride);
-}
+	inline double cblas_Xasum(const int N, const double *X, const int incX) {
+		return cblas_dasum(N, X, incX);
+	}
 
-// Implements  A += alpha * (x y'  + y x'); A is symmetric matrix.
-inline void cblas_Xspr2(MatrixIndexT dim, float alpha, const float *Xdata,
-                        MatrixIndexT incX, const float *Ydata, MatrixIndexT incY,
-                          float *Adata) {
-  cblas_sspr2(CblasRowMajor, CblasLower, dim, alpha, Xdata,
-              incX, Ydata, incY, Adata);
-}
-inline void cblas_Xspr2(MatrixIndexT dim, double alpha, const double *Xdata,
-                        MatrixIndexT incX, const double *Ydata, MatrixIndexT incY,
-                        double *Adata) {
-  cblas_dspr2(CblasRowMajor, CblasLower, dim, alpha, Xdata,
-              incX, Ydata, incY, Adata);
-}
-
-// Implements  A += alpha * (x x'); A is symmetric matrix.
-inline void cblas_Xspr(MatrixIndexT dim, float alpha, const float *Xdata,
-                       MatrixIndexT incX, float *Adata) {
-  cblas_sspr(CblasRowMajor, CblasLower, dim, alpha, Xdata, incX, Adata);
-}
-inline void cblas_Xspr(MatrixIndexT dim, double alpha, const double *Xdata,
-                       MatrixIndexT incX, double *Adata) {
-  cblas_dspr(CblasRowMajor, CblasLower, dim, alpha, Xdata, incX, Adata);
-}
-
-// sgemv,dgemv: y = alpha M x + beta y.
-inline void cblas_Xgemv(MatrixTransposeType trans, MatrixIndexT num_rows,
-                        MatrixIndexT num_cols, float alpha, const float *Mdata,
-                        MatrixIndexT stride, const float *xdata,
-                        MatrixIndexT incX, float beta, float *ydata, MatrixIndexT incY) {
-  cblas_sgemv(CblasRowMajor, static_cast<CBLAS_TRANSPOSE>(trans), num_rows,
-              num_cols, alpha, Mdata, stride, xdata, incX, beta, ydata, incY);
-}
-inline void cblas_Xgemv(MatrixTransposeType trans, MatrixIndexT num_rows,
-                        MatrixIndexT num_cols, double alpha, const double *Mdata,
-                        MatrixIndexT stride, const double *xdata,
-                        MatrixIndexT incX, double beta, double *ydata, MatrixIndexT incY) {
-  cblas_dgemv(CblasRowMajor, static_cast<CBLAS_TRANSPOSE>(trans), num_rows,
-              num_cols, alpha, Mdata, stride, xdata, incX, beta, ydata, incY);
-}
-
-// sgbmv, dgmmv: y = alpha M x +  + beta * y.
-inline void cblas_Xgbmv(MatrixTransposeType trans, MatrixIndexT num_rows,
-                        MatrixIndexT num_cols, MatrixIndexT num_below,
-                        MatrixIndexT num_above, float alpha, const float *Mdata,
-                        MatrixIndexT stride, const float *xdata,
-                        MatrixIndexT incX, float beta, float *ydata, MatrixIndexT incY) {
-  cblas_sgbmv(CblasRowMajor, static_cast<CBLAS_TRANSPOSE>(trans), num_rows,
-              num_cols, num_below, num_above, alpha, Mdata, stride, xdata,
-              incX, beta, ydata, incY);
-}
-inline void cblas_Xgbmv(MatrixTransposeType trans, MatrixIndexT num_rows,
-                        MatrixIndexT num_cols, MatrixIndexT num_below,
-                        MatrixIndexT num_above, double alpha, const double *Mdata,
-                        MatrixIndexT stride, const double *xdata,
-                        MatrixIndexT incX, double beta, double *ydata, MatrixIndexT incY) {
-  cblas_dgbmv(CblasRowMajor, static_cast<CBLAS_TRANSPOSE>(trans), num_rows,
-              num_cols, num_below, num_above, alpha, Mdata, stride, xdata,
-              incX, beta, ydata, incY);
-}
+	inline void cblas_Xrot(const int N, float *X, const int incX, float *Y,
+		const int incY, const float c, const float s) {
+		cblas_srot(N, X, incX, Y, incY, c, s);
+	}
+	inline void cblas_Xrot(const int N, double *X, const int incX, double *Y,
+		const int incY, const double c, const double s) {
+		cblas_drot(N, X, incX, Y, incY, c, s);
+	}
+	inline float cblas_Xdot(const int N, const float *const X,
+		const int incX, const float *const Y,
+		const int incY) {
+		return cblas_sdot(N, X, incX, Y, incY);
+	}
+	inline double cblas_Xdot(const int N, const double *const X,
+		const int incX, const double *const Y,
+		const int incY) {
+		return cblas_ddot(N, X, incX, Y, incY);
+	}
+	inline void cblas_Xaxpy(const int N, const float alpha, const float *X,
+		const int incX, float *Y, const int incY) {
+		cblas_saxpy(N, alpha, X, incX, Y, incY);
+	}
+	inline void cblas_Xaxpy(const int N, const double alpha, const double *X,
+		const int incX, double *Y, const int incY) {
+		cblas_daxpy(N, alpha, X, incX, Y, incY);
+	}
+	inline void cblas_Xscal(const int N, const float alpha, float *data,
+		const int inc) {
+		cblas_sscal(N, alpha, data, inc);
+	}
+	inline void cblas_Xscal(const int N, const double alpha, double *data,
+		const int inc) {
+		cblas_dscal(N, alpha, data, inc);
+	}
+	inline void cblas_Xspmv(const float alpha, const int num_rows, const float *Mdata,
+		const float *v, const int v_inc,
+		const float beta, float *y, const int y_inc) {
+		cblas_sspmv(CblasLower, num_rows, alpha, Mdata, v, v_inc, beta, y, y_inc);
+	}
+	inline void cblas_Xspmv(const double alpha, const int num_rows, const double *Mdata,
+		const double *v, const int v_inc,
+		const double beta, double *y, const int y_inc) {
+		cblas_dspmv(CblasLower, num_rows, alpha, Mdata, v, v_inc, beta, y, y_inc);
+	}
+	inline void cblas_Xtpmv(MatrixTransposeType trans, const float *Mdata,
+		const int num_rows, float *y, const int y_inc) {
+		cblas_stpmv(CblasLower, static_cast<CBLAS_TRANSPOSE>(trans),
+			CblasNonUnit, num_rows, Mdata, y, y_inc);
+	}
+	inline void cblas_Xtpmv(MatrixTransposeType trans, const double *Mdata,
+		const int num_rows, double *y, const int y_inc) {
+		cblas_dtpmv(CblasLower, static_cast<CBLAS_TRANSPOSE>(trans),
+			CblasNonUnit, num_rows, Mdata, y, y_inc);
+	}
 
 
-template<typename Real>
-inline void Xgemv_sparsevec(MatrixTransposeType trans, MatrixIndexT num_rows,
-                            MatrixIndexT num_cols, Real alpha, const Real *Mdata,
-                            MatrixIndexT stride, const Real *xdata,
-                            MatrixIndexT incX, Real beta, Real *ydata,
-                            MatrixIndexT incY) {
-  if (trans == kNoTrans) {
-    if (beta != 1.0) cblas_Xscal(num_rows, beta, ydata, incY);
-    for (MatrixIndexT i = 0; i < num_cols; i++) {
-      Real x_i = xdata[i * incX];
-      if (x_i == 0.0) continue;
-      // Add to ydata, the i'th column of M, times alpha * x_i
-      cblas_Xaxpy(num_rows, x_i * alpha, Mdata + i, stride, ydata, incY);
-    }    
-  } else {
-    if (beta != 1.0) cblas_Xscal(num_cols, beta, ydata, incY);
-    for (MatrixIndexT i = 0; i < num_rows; i++) {
-      Real x_i = xdata[i * incX];
-      if (x_i == 0.0) continue;
-      // Add to ydata, the i'th row of M, times alpha * x_i
-      cblas_Xaxpy(num_cols, x_i * alpha,
-                  Mdata + (i * stride), 1, ydata, incY);
-    }
-  }
-}
+	inline void cblas_Xtpsv(MatrixTransposeType trans, const float *Mdata,
+		const int num_rows, float *y, const int y_inc) {
+		cblas_stpsv(CblasLower, static_cast<CBLAS_TRANSPOSE>(trans),
+			CblasNonUnit, num_rows, Mdata, y, y_inc);
+	}
+	inline void cblas_Xtpsv(MatrixTransposeType trans, const double *Mdata,
+		const int num_rows, double *y, const int y_inc) {
+		cblas_dtpsv(CblasLower, static_cast<CBLAS_TRANSPOSE>(trans),
+			CblasNonUnit, num_rows, Mdata, y, y_inc);
+	}
 
-inline void cblas_Xgemm(const float alpha,
-                        MatrixTransposeType transA,
-                        const float *Adata,
-                        MatrixIndexT a_num_rows, MatrixIndexT a_num_cols, MatrixIndexT a_stride,
-                        MatrixTransposeType transB, 
-                        const float *Bdata, MatrixIndexT b_stride,
-                        const float beta,
-                        float *Mdata, 
-                        MatrixIndexT num_rows, MatrixIndexT num_cols,MatrixIndexT stride) {
-  cblas_sgemm(CblasRowMajor, static_cast<CBLAS_TRANSPOSE>(transA), 
-              static_cast<CBLAS_TRANSPOSE>(transB),
-              num_rows, num_cols, transA == kNoTrans ? a_num_cols : a_num_rows,
-              alpha, Adata, a_stride, Bdata, b_stride,
-              beta, Mdata, stride); 
-}
-inline void cblas_Xgemm(const double alpha,
-                        MatrixTransposeType transA,
-                        const double *Adata,
-                        MatrixIndexT a_num_rows, MatrixIndexT a_num_cols, MatrixIndexT a_stride,
-                        MatrixTransposeType transB, 
-                        const double *Bdata, MatrixIndexT b_stride,
-                        const double beta,
-                        double *Mdata, 
-                        MatrixIndexT num_rows, MatrixIndexT num_cols,MatrixIndexT stride) {
-  cblas_dgemm(CblasRowMajor, static_cast<CBLAS_TRANSPOSE>(transA), 
-              static_cast<CBLAS_TRANSPOSE>(transB),
-              num_rows, num_cols, transA == kNoTrans ? a_num_cols : a_num_rows,
-              alpha, Adata, a_stride, Bdata, b_stride,
-              beta, Mdata, stride); 
-}
+	// x = alpha * M * y + beta * x
+	inline void cblas_Xspmv(MatrixIndexT dim, float alpha, const float *Mdata,
+		const float *ydata, MatrixIndexT ystride,
+		float beta, float *xdata, MatrixIndexT xstride) {
+		cblas_sspmv(CblasLower, dim, alpha, Mdata,
+			ydata, ystride, beta, xdata, xstride);
+	}
+	inline void cblas_Xspmv(MatrixIndexT dim, double alpha, const double *Mdata,
+		const double *ydata, MatrixIndexT ystride,
+		double beta, double *xdata, MatrixIndexT xstride) {
+		cblas_dspmv(CblasLower, dim, alpha, Mdata,
+			ydata, ystride, beta, xdata, xstride);
+	}
 
+	// Implements  A += alpha * (x y'  + y x'); A is symmetric matrix.
+	inline void cblas_Xspr2(MatrixIndexT dim, float alpha, const float *Xdata,
+		MatrixIndexT incX, const float *Ydata, MatrixIndexT incY,
+		float *Adata) {
+		cblas_sspr2(CblasLower, dim, alpha, Xdata,
+			incX, Ydata, incY, Adata);
+	}
+	inline void cblas_Xspr2(MatrixIndexT dim, double alpha, const double *Xdata,
+		MatrixIndexT incX, const double *Ydata, MatrixIndexT incY,
+		double *Adata) {
+		cblas_dspr2(CblasLower, dim, alpha, Xdata,
+			incX, Ydata, incY, Adata);
+	}
 
-inline void cblas_Xsymm(const float alpha,
-                        MatrixIndexT sz,
-                        const float *Adata,MatrixIndexT a_stride,
-                        const float *Bdata,MatrixIndexT b_stride,
-                        const float beta,
-                        float *Mdata, MatrixIndexT stride) {
-  cblas_ssymm(CblasRowMajor, CblasLeft, CblasLower, sz, sz, alpha, Adata,
-              a_stride, Bdata, b_stride, beta, Mdata, stride);
-}
-inline void cblas_Xsymm(const double alpha,
-                        MatrixIndexT sz,
-                        const double *Adata,MatrixIndexT a_stride,
-                        const double *Bdata,MatrixIndexT b_stride,
-                        const double beta,
-                        double *Mdata, MatrixIndexT stride) {
-  cblas_dsymm(CblasRowMajor, CblasLeft, CblasLower, sz, sz, alpha, Adata,
-              a_stride, Bdata, b_stride, beta, Mdata, stride);
-}
-// ger: M += alpha x y^T.
-inline void cblas_Xger(MatrixIndexT num_rows, MatrixIndexT num_cols, float alpha,
-                       const float *xdata, MatrixIndexT incX, const float *ydata,
-                       MatrixIndexT incY, float *Mdata, MatrixIndexT stride) {
-  cblas_sger(CblasRowMajor, num_rows, num_cols, alpha, xdata, 1, ydata, 1,
-             Mdata, stride);
-}
-inline void cblas_Xger(MatrixIndexT num_rows, MatrixIndexT num_cols, double alpha,
-                       const double *xdata, MatrixIndexT incX, const double *ydata,
-                       MatrixIndexT incY, double *Mdata, MatrixIndexT stride) {
-  cblas_dger(CblasRowMajor, num_rows, num_cols, alpha, xdata, 1, ydata, 1,
-             Mdata, stride);
-}
+	// Implements  A += alpha * (x x'); A is symmetric matrix.
+	inline void cblas_Xspr(MatrixIndexT dim, float alpha, const float *Xdata,
+		MatrixIndexT incX, float *Adata) {
+		cblas_sspr(CblasLower, dim, alpha, Xdata, incX, Adata);
+	}
+	inline void cblas_Xspr(MatrixIndexT dim, double alpha, const double *Xdata,
+		MatrixIndexT incX, double *Adata) {
+		cblas_dspr(CblasLower, dim, alpha, Xdata, incX, Adata);
+	}
 
-// syrk: symmetric rank-k update.
-// if trans==kNoTrans, then C = alpha A A^T + beta C
-// else C = alpha A^T A + beta C.
-// note: dim_c is dim(C), other_dim_a is the "other" dimension of A, i.e.
-// num-cols(A) if kNoTrans, or num-rows(A) if kTrans.
-// We only need the row-major and lower-triangular option of this, and this
-// is hard-coded.
-inline void cblas_Xsyrk (
-    const MatrixTransposeType trans, const MatrixIndexT dim_c,
-    const MatrixIndexT other_dim_a, const float alpha, const float *A,
-    const MatrixIndexT a_stride, const float beta, float *C,
-    const MatrixIndexT c_stride) {
-  cblas_ssyrk(CblasRowMajor, CblasLower, static_cast<CBLAS_TRANSPOSE>(trans),
-              dim_c, other_dim_a, alpha, A, a_stride, beta, C, c_stride);
-}
+	// sgemv,dgemv: y = alpha M x + beta y.
+	inline void cblas_Xgemv(MatrixTransposeType trans, MatrixIndexT num_rows,
+		MatrixIndexT num_cols, float alpha, const float *Mdata,
+		MatrixIndexT stride, const float *xdata,
+		MatrixIndexT incX, float beta, float *ydata, MatrixIndexT incY) {
+		cblas_sgemv(static_cast<CBLAS_TRANSPOSE>(trans), num_rows,
+			num_cols, alpha, Mdata, stride, xdata, incX, beta, ydata, incY);
+	}
+	inline void cblas_Xgemv(MatrixTransposeType trans, MatrixIndexT num_rows,
+		MatrixIndexT num_cols, double alpha, const double *Mdata,
+		MatrixIndexT stride, const double *xdata,
+		MatrixIndexT incX, double beta, double *ydata, MatrixIndexT incY) {
+		cblas_dgemv(static_cast<CBLAS_TRANSPOSE>(trans), &num_rows,
+			num_cols, alpha, Mdata, stride, xdata, incX, beta, ydata, incY);
+	}
 
-inline void cblas_Xsyrk(
-    const MatrixTransposeType trans, const MatrixIndexT dim_c,
-    const MatrixIndexT other_dim_a, const double alpha, const double *A,
-    const MatrixIndexT a_stride, const double beta, double *C,
-    const MatrixIndexT c_stride) {
-  cblas_dsyrk(CblasRowMajor, CblasLower, static_cast<CBLAS_TRANSPOSE>(trans),
-              dim_c, other_dim_a, alpha, A, a_stride, beta, C, c_stride);
-}
-
-/// matrix-vector multiply using a banded matrix; we always call this
-/// with b = 1 meaning we're multiplying by a diagonal matrix.  This is used for
-/// elementwise multiplication.  We miss some of the arguments out of this
-/// wrapper.
-inline void cblas_Xsbmv1(
-    const MatrixIndexT dim,
-    const double *A,
-    const double alpha,
-    const double *x,
-    const double beta,
-    double *y) {
-  cblas_dsbmv(CblasRowMajor, CblasLower, dim, 0, alpha, A,
-              1, x, 1, beta, y, 1);
-}
-
-inline void cblas_Xsbmv1(
-    const MatrixIndexT dim,
-    const float *A,
-    const float alpha,
-    const float *x,
-    const float beta,
-    float *y) {
-  cblas_ssbmv(CblasRowMajor, CblasLower, dim, 0, alpha, A,
-              1, x, 1, beta, y, 1);
-}
+	// sgbmv, dgmmv: y = alpha M x +  + beta * y.
+	inline void cblas_Xgbmv(MatrixTransposeType trans, MatrixIndexT num_rows,
+		MatrixIndexT num_cols, MatrixIndexT num_below,
+		MatrixIndexT num_above, float alpha, const float *Mdata,
+		MatrixIndexT stride, const float *xdata,
+		MatrixIndexT incX, float beta, float *ydata, MatrixIndexT incY) {
+		cblas_sgbmv(static_cast<CBLAS_TRANSPOSE>(trans), num_rows,
+			num_cols, num_below, num_above, alpha, Mdata, stride, xdata,
+			incX, beta, ydata, incY);
+	}
+	inline void cblas_Xgbmv(MatrixTransposeType trans, MatrixIndexT num_rows,
+		MatrixIndexT num_cols, MatrixIndexT num_below,
+		MatrixIndexT num_above, double alpha, const double *Mdata,
+		MatrixIndexT stride, const double *xdata,
+		MatrixIndexT incX, double beta, double *ydata, MatrixIndexT incY) {
+		cblas_dgbmv(static_cast<CBLAS_TRANSPOSE>(trans), num_rows,
+			num_cols, num_below, num_above, alpha, Mdata, stride, xdata,
+			incX, beta, ydata, incY);
+	}
 
 
-/// This is not really a wrapper for CBLAS as CBLAS does not have this; in future we could
-/// extend this somehow.
-inline void mul_elements(
-    const MatrixIndexT dim,
-    const double *a,
-    double *b) { // does b *= a, elementwise.
-  double c1, c2, c3, c4;
-  MatrixIndexT i;
-  for (i = 0; i + 4 <= dim; i += 4) {
-    c1 = a[i] * b[i];
-    c2 = a[i+1] * b[i+1];
-    c3 = a[i+2] * b[i+2];
-    c4 = a[i+3] * b[i+3];
-    b[i] = c1;
-    b[i+1] = c2;
-    b[i+2] = c3;
-    b[i+3] = c4;
-  }
-  for (; i < dim; i++)
-    b[i] *= a[i];
-}
+	template<typename Real>
+	inline void Xgemv_sparsevec(MatrixTransposeType trans, MatrixIndexT num_rows,
+		MatrixIndexT num_cols, Real alpha, const Real *Mdata,
+		MatrixIndexT stride, const Real *xdata,
+		MatrixIndexT incX, Real beta, Real *ydata,
+		MatrixIndexT incY) {
+		if (trans == kNoTrans) {
+			if (beta != 1.0) cblas_Xscal(num_rows, beta, ydata, incY);
+			for (MatrixIndexT i = 0; i < num_cols; i++) {
+				Real x_i = xdata[i * incX];
+				if (x_i == 0.0) continue;
+				// Add to ydata, the i'th column of M, times alpha * x_i
+				cblas_Xaxpy(num_rows, x_i * alpha, Mdata + i, stride, ydata, incY);
+			}
+		}
+		else {
+			if (beta != 1.0) cblas_Xscal(num_cols, beta, ydata, incY);
+			for (MatrixIndexT i = 0; i < num_rows; i++) {
+				Real x_i = xdata[i * incX];
+				if (x_i == 0.0) continue;
+				// Add to ydata, the i'th row of M, times alpha * x_i
+				cblas_Xaxpy(num_cols, x_i * alpha,
+					Mdata + (i * stride), 1, ydata, incY);
+			}
+		}
+	}
 
-inline void mul_elements(
-    const MatrixIndexT dim,
-    const float *a,
-    float *b) { // does b *= a, elementwise.
-  float c1, c2, c3, c4;
-  MatrixIndexT i;
-  for (i = 0; i + 4 <= dim; i += 4) {
-    c1 = a[i] * b[i];
-    c2 = a[i+1] * b[i+1];
-    c3 = a[i+2] * b[i+2];
-    c4 = a[i+3] * b[i+3];
-    b[i] = c1;
-    b[i+1] = c2;
-    b[i+2] = c3;
-    b[i+3] = c4;
-  }
-  for (; i < dim; i++)
-    b[i] *= a[i];
-}
+	inline void cblas_Xgemm(const float alpha,
+		MatrixTransposeType transA,
+		const float *Adata,
+		MatrixIndexT a_num_rows, MatrixIndexT a_num_cols, MatrixIndexT a_stride,
+		MatrixTransposeType transB,
+		const float *Bdata, MatrixIndexT b_stride,
+		const float beta,
+		float *Mdata,
+		MatrixIndexT num_rows, MatrixIndexT num_cols, MatrixIndexT stride) {
+		cblas_sgemm(static_cast<CBLAS_TRANSPOSE>(transA),
+			static_cast<CBLAS_TRANSPOSE>(transB),
+			num_rows, num_cols, transA == kNoTrans ? a_num_cols : a_num_rows,
+			alpha, Adata, a_stride, Bdata, b_stride,
+			beta, Mdata, stride);
+	}
+	inline void cblas_Xgemm(const double alpha,
+		MatrixTransposeType transA,
+		const double *Adata,
+		MatrixIndexT a_num_rows, MatrixIndexT a_num_cols, MatrixIndexT a_stride,
+		MatrixTransposeType transB,
+		const double *Bdata, MatrixIndexT b_stride,
+		const double beta,
+		double *Mdata,
+		MatrixIndexT num_rows, MatrixIndexT num_cols, MatrixIndexT stride) {
+		cblas_dgemm(static_cast<CBLAS_TRANSPOSE>(transA),
+			static_cast<CBLAS_TRANSPOSE>(transB),
+			num_rows, num_cols, transA == kNoTrans ? a_num_cols : a_num_rows,
+			alpha, Adata, a_stride, Bdata, b_stride,
+			beta, Mdata, stride);
+	}
+
+
+	inline void cblas_Xsymm(const float alpha,
+		MatrixIndexT sz,
+		const float *Adata, MatrixIndexT a_stride,
+		const float *Bdata, MatrixIndexT b_stride,
+		const float beta,
+		float *Mdata, MatrixIndexT stride) {
+		cblas_ssymm(CblasLeft, CblasLower, sz, sz, alpha, Adata,
+			a_stride, Bdata, b_stride, beta, Mdata, stride);
+	}
+	inline void cblas_Xsymm(const double alpha,
+		MatrixIndexT sz,
+		const double *Adata, MatrixIndexT a_stride,
+		const double *Bdata, MatrixIndexT b_stride,
+		const double beta,
+		double *Mdata, MatrixIndexT stride) {
+		cblas_dsymm(CblasLeft, CblasLower, sz, sz, alpha, Adata,
+			a_stride, Bdata, b_stride, beta, Mdata, stride);
+	}
+	// ger: M += alpha x y^T.
+	inline void cblas_Xger(MatrixIndexT num_rows, MatrixIndexT num_cols, float alpha,
+		const float *xdata, MatrixIndexT incX, const float *ydata,
+		MatrixIndexT incY, float *Mdata, MatrixIndexT stride) {
+		cblas_sger(num_rows, num_cols, alpha, xdata, 1, ydata, 1,
+			Mdata, stride);
+	}
+	inline void cblas_Xger(MatrixIndexT num_rows, MatrixIndexT num_cols, double alpha,
+		const double *xdata, MatrixIndexT incX, const double *ydata,
+		MatrixIndexT incY, double *Mdata, MatrixIndexT stride) {
+		cblas_dger(num_rows, num_cols, alpha, xdata, 1, ydata, 1,
+			Mdata, stride);
+	}
+
+	// syrk: symmetric rank-k update.
+	// if trans==kNoTrans, then C = alpha A A^T + beta C
+	// else C = alpha A^T A + beta C.
+	// note: dim_c is dim(C), other_dim_a is the "other" dimension of A, i.e.
+	// num-cols(A) if kNoTrans, or num-rows(A) if kTrans.
+	// We only need the row-major and lower-triangular option of this, and this
+	// is hard-coded.
+	inline void cblas_Xsyrk(
+		const MatrixTransposeType trans, const MatrixIndexT dim_c,
+		const MatrixIndexT other_dim_a, const float alpha, const float *A,
+		const MatrixIndexT a_stride, const float beta, float *C,
+		const MatrixIndexT c_stride) {
+		cblas_ssyrk(CblasLower, static_cast<CBLAS_TRANSPOSE>(trans),
+			dim_c, other_dim_a, alpha, A, a_stride, beta, C, c_stride);
+	}
+
+	inline void cblas_Xsyrk(
+		const MatrixTransposeType trans, const MatrixIndexT dim_c,
+		const MatrixIndexT other_dim_a, const double alpha, const double *A,
+		const MatrixIndexT a_stride, const double beta, double *C,
+		const MatrixIndexT c_stride) {
+		cblas_dsyrk(CblasLower, static_cast<CBLAS_TRANSPOSE>(trans),
+			dim_c, other_dim_a, alpha, A, a_stride, beta, C, c_stride);
+	}
+
+	/// matrix-vector multiply using a banded matrix; we always call this
+	/// with b = 1 meaning we're multiplying by a diagonal matrix.  This is used for
+	/// elementwise multiplication.  We miss some of the arguments out of this
+	/// wrapper.
+	inline void cblas_Xsbmv1(
+		const MatrixIndexT dim,
+		const double *A,
+		const double alpha,
+		const double *x,
+		const double beta,
+		double *y) {
+		cblas_dsbmv(CblasLower, dim, 0, alpha, A,
+			1, x, 1, beta, y, 1);
+	}
+
+	inline void cblas_Xsbmv1(
+		const MatrixIndexT dim,
+		const float *A,
+		const float alpha,
+		const float *x,
+		const float beta,
+		float *y) {
+		cblas_ssbmv(CblasLower, dim, 0, alpha, A,
+			1, x, 1, beta, y, 1);
+	}
+
+
+	/// This is not really a wrapper for CBLAS as CBLAS does not have this; in future we could
+	/// extend this somehow.
+	inline void mul_elements(
+		const MatrixIndexT dim,
+		const double *a,
+		double *b) { // does b *= a, elementwise.
+		double c1, c2, c3, c4;
+		MatrixIndexT i;
+		for (i = 0; i + 4 <= dim; i += 4) {
+			c1 = a[i] * b[i];
+			c2 = a[i + 1] * b[i + 1];
+			c3 = a[i + 2] * b[i + 2];
+			c4 = a[i + 3] * b[i + 3];
+			b[i] = c1;
+			b[i + 1] = c2;
+			b[i + 2] = c3;
+			b[i + 3] = c4;
+		}
+		for (; i < dim; i++)
+			b[i] *= a[i];
+	}
+
+	inline void mul_elements(
+		const MatrixIndexT dim,
+		const float *a,
+		float *b) { // does b *= a, elementwise.
+		float c1, c2, c3, c4;
+		MatrixIndexT i;
+		for (i = 0; i + 4 <= dim; i += 4) {
+			c1 = a[i] * b[i];
+			c2 = a[i + 1] * b[i + 1];
+			c3 = a[i + 2] * b[i + 2];
+			c4 = a[i + 3] * b[i + 3];
+			b[i] = c1;
+			b[i + 1] = c2;
+			b[i + 2] = c3;
+			b[i + 3] = c4;
+		}
+		for (; i < dim; i++)
+			b[i] *= a[i];
+	}
 
 
 
-// add clapack here
+	// add clapack here
 #if !defined(HAVE_ATLAS)
-inline void clapack_Xtptri(KaldiBlasInt *num_rows, float *Mdata, KaldiBlasInt *result) {
-  stptri_(const_cast<char *>("U"), const_cast<char *>("N"), num_rows, Mdata, result);
-}
-inline void clapack_Xtptri(KaldiBlasInt *num_rows, double *Mdata, KaldiBlasInt *result) {
-  dtptri_(const_cast<char *>("U"), const_cast<char *>("N"), num_rows, Mdata, result);
-}
-// 
-inline void clapack_Xgetrf2(KaldiBlasInt *num_rows, KaldiBlasInt *num_cols, 
-                            float *Mdata, KaldiBlasInt *stride, KaldiBlasInt *pivot, 
-                            KaldiBlasInt *result) {
-  sgetrf_(num_rows, num_cols, Mdata, stride, pivot, result);
-}
-inline void clapack_Xgetrf2(KaldiBlasInt *num_rows, KaldiBlasInt *num_cols, 
-                            double *Mdata, KaldiBlasInt *stride, KaldiBlasInt *pivot, 
-                            KaldiBlasInt *result) {
-  dgetrf_(num_rows, num_cols, Mdata, stride, pivot, result);
-}
+	inline void clapack_Xtptri(KaldiBlasInt *num_rows, float *Mdata, KaldiBlasInt *result) {
+		stptri_(const_cast<char *>("U"), const_cast<char *>("N"), num_rows, Mdata, result);
+	}
+	inline void clapack_Xtptri(KaldiBlasInt *num_rows, double *Mdata, KaldiBlasInt *result) {
+		dtptri_(const_cast<char *>("U"), const_cast<char *>("N"), num_rows, Mdata, result);
+	}
+	// 
+	inline void clapack_Xgetrf2(KaldiBlasInt *num_rows, KaldiBlasInt *num_cols,
+		float *Mdata, KaldiBlasInt *stride, KaldiBlasInt *pivot,
+		KaldiBlasInt *result) {
+		sgetrf_(num_rows, num_cols, Mdata, stride, pivot, result);
+	}
+	inline void clapack_Xgetrf2(KaldiBlasInt *num_rows, KaldiBlasInt *num_cols,
+		double *Mdata, KaldiBlasInt *stride, KaldiBlasInt *pivot,
+		KaldiBlasInt *result) {
+		dgetrf_(num_rows, num_cols, Mdata, stride, pivot, result);
+	}
 
-// 
-inline void clapack_Xgetri2(KaldiBlasInt *num_rows, float *Mdata, KaldiBlasInt *stride,
-                           KaldiBlasInt *pivot, float *p_work, 
-                           KaldiBlasInt *l_work, KaldiBlasInt *result) {
-  sgetri_(num_rows, Mdata, stride, pivot, p_work, l_work, result);
-}
-inline void clapack_Xgetri2(KaldiBlasInt *num_rows, double *Mdata, KaldiBlasInt *stride,
-                           KaldiBlasInt *pivot, double *p_work, 
-                           KaldiBlasInt *l_work, KaldiBlasInt *result) {
-  dgetri_(num_rows, Mdata, stride, pivot, p_work, l_work, result);
-}
-//
-inline void clapack_Xgesvd(char *v, char *u, KaldiBlasInt *num_cols,
-                           KaldiBlasInt *num_rows, float *Mdata, KaldiBlasInt *stride,
-                           float *sv, float *Vdata, KaldiBlasInt *vstride,
-                           float *Udata, KaldiBlasInt *ustride, float *p_work,
-                           KaldiBlasInt *l_work, KaldiBlasInt *result) {
-  sgesvd_(v, u,
-          num_cols, num_rows, Mdata, stride,
-          sv, Vdata, vstride, Udata, ustride, 
-          p_work, l_work, result); 
-}
-inline void clapack_Xgesvd(char *v, char *u, KaldiBlasInt *num_cols,
-                           KaldiBlasInt *num_rows, double *Mdata, KaldiBlasInt *stride,
-                           double *sv, double *Vdata, KaldiBlasInt *vstride,
-                           double *Udata, KaldiBlasInt *ustride, double *p_work,
-                           KaldiBlasInt *l_work, KaldiBlasInt *result) {
-  dgesvd_(v, u,
-          num_cols, num_rows, Mdata, stride,
-          sv, Vdata, vstride, Udata, ustride,
-          p_work, l_work, result); 
-}
-//
-void inline clapack_Xsptri(KaldiBlasInt *num_rows, float *Mdata, 
-                           KaldiBlasInt *ipiv, float *work, KaldiBlasInt *result) {
-  ssptri_(const_cast<char *>("U"), num_rows, Mdata, ipiv, work, result);
-}
-void inline clapack_Xsptri(KaldiBlasInt *num_rows, double *Mdata, 
-                           KaldiBlasInt *ipiv, double *work, KaldiBlasInt *result) {
-  dsptri_(const_cast<char *>("U"), num_rows, Mdata, ipiv, work, result);
-}
-//
-void inline clapack_Xsptrf(KaldiBlasInt *num_rows, float *Mdata,
-                           KaldiBlasInt *ipiv, KaldiBlasInt *result) {
-  ssptrf_(const_cast<char *>("U"), num_rows, Mdata, ipiv, result);
-}
-void inline clapack_Xsptrf(KaldiBlasInt *num_rows, double *Mdata,
-                           KaldiBlasInt *ipiv, KaldiBlasInt *result) {
-  dsptrf_(const_cast<char *>("U"), num_rows, Mdata, ipiv, result);
-}
+	// 
+	inline void clapack_Xgetri2(KaldiBlasInt *num_rows, float *Mdata, KaldiBlasInt *stride,
+		KaldiBlasInt *pivot, float *p_work,
+		KaldiBlasInt *l_work, KaldiBlasInt *result) {
+		sgetri_(num_rows, Mdata, stride, pivot, p_work, l_work, result);
+	}
+	inline void clapack_Xgetri2(KaldiBlasInt *num_rows, double *Mdata, KaldiBlasInt *stride,
+		KaldiBlasInt *pivot, double *p_work,
+		KaldiBlasInt *l_work, KaldiBlasInt *result) {
+		dgetri_(num_rows, Mdata, stride, pivot, p_work, l_work, result);
+	}
+	//
+	inline void clapack_Xgesvd(char *v, char *u, KaldiBlasInt *num_cols,
+		KaldiBlasInt *num_rows, float *Mdata, KaldiBlasInt *stride,
+		float *sv, float *Vdata, KaldiBlasInt *vstride,
+		float *Udata, KaldiBlasInt *ustride, float *p_work,
+		KaldiBlasInt *l_work, KaldiBlasInt *result) {
+		sgesvd_(v, u,
+			num_cols, num_rows, Mdata, stride,
+			sv, Vdata, vstride, Udata, ustride,
+			p_work, l_work, result);
+	}
+	inline void clapack_Xgesvd(char *v, char *u, KaldiBlasInt *num_cols,
+		KaldiBlasInt *num_rows, double *Mdata, KaldiBlasInt *stride,
+		double *sv, double *Vdata, KaldiBlasInt *vstride,
+		double *Udata, KaldiBlasInt *ustride, double *p_work,
+		KaldiBlasInt *l_work, KaldiBlasInt *result) {
+		dgesvd_(v, u,
+			num_cols, num_rows, Mdata, stride,
+			sv, Vdata, vstride, Udata, ustride,
+			p_work, l_work, result);
+	}
+	//
+	void inline clapack_Xsptri(KaldiBlasInt *num_rows, float *Mdata,
+		KaldiBlasInt *ipiv, float *work, KaldiBlasInt *result) {
+		ssptri_(const_cast<char *>("U"), num_rows, Mdata, ipiv, work, result);
+	}
+	void inline clapack_Xsptri(KaldiBlasInt *num_rows, double *Mdata,
+		KaldiBlasInt *ipiv, double *work, KaldiBlasInt *result) {
+		dsptri_(const_cast<char *>("U"), num_rows, Mdata, ipiv, work, result);
+	}
+	//
+	void inline clapack_Xsptrf(KaldiBlasInt *num_rows, float *Mdata,
+		KaldiBlasInt *ipiv, KaldiBlasInt *result) {
+		ssptrf_(const_cast<char *>("U"), num_rows, Mdata, ipiv, result);
+	}
+	void inline clapack_Xsptrf(KaldiBlasInt *num_rows, double *Mdata,
+		KaldiBlasInt *ipiv, KaldiBlasInt *result) {
+		dsptrf_(const_cast<char *>("U"), num_rows, Mdata, ipiv, result);
+	}
 #else
-inline void clapack_Xgetrf(MatrixIndexT num_rows, MatrixIndexT num_cols,
-                           float *Mdata, MatrixIndexT stride, 
-                           int *pivot, int *result) {
-  *result = clapack_sgetrf(CblasColMajor, num_rows, num_cols,
-                              Mdata, stride, pivot);
-}
+	inline void clapack_Xgetrf(MatrixIndexT num_rows, MatrixIndexT num_cols,
+		float *Mdata, MatrixIndexT stride,
+		int *pivot, int *result) {
+		*result = clapack_sgetrf(CblasColMajor, num_rows, num_cols,
+			Mdata, stride, pivot);
+	}
 
-inline void clapack_Xgetrf(MatrixIndexT num_rows, MatrixIndexT num_cols,
-                           double *Mdata, MatrixIndexT stride, 
-                           int *pivot, int *result) {
-  *result = clapack_dgetrf(CblasColMajor, num_rows, num_cols,
-                              Mdata, stride, pivot);
-}
-//
-inline int clapack_Xtrtri(int num_rows, float *Mdata, MatrixIndexT stride) {
-  return  clapack_strtri(CblasColMajor, CblasUpper, CblasNonUnit, num_rows,
-                              Mdata, stride);
-}
+	inline void clapack_Xgetrf(MatrixIndexT num_rows, MatrixIndexT num_cols,
+		double *Mdata, MatrixIndexT stride,
+		int *pivot, int *result) {
+		*result = clapack_dgetrf(CblasColMajor, num_rows, num_cols,
+			Mdata, stride, pivot);
+	}
+	//
+	inline int clapack_Xtrtri(int num_rows, float *Mdata, MatrixIndexT stride) {
+		return  clapack_strtri(CblasColMajor, CblasUpper, CblasNonUnit, num_rows,
+			Mdata, stride);
+	}
 
-inline int clapack_Xtrtri(int num_rows, double *Mdata, MatrixIndexT stride) {
-  return  clapack_dtrtri(CblasColMajor, CblasUpper, CblasNonUnit, num_rows,
-                              Mdata, stride);
-}
-//
-inline void clapack_Xgetri(MatrixIndexT num_rows, float *Mdata, MatrixIndexT stride,
-                      int *pivot, int *result) {
-  *result = clapack_sgetri(CblasColMajor, num_rows, Mdata, stride, pivot);
-}
-inline void clapack_Xgetri(MatrixIndexT num_rows, double *Mdata, MatrixIndexT stride,
-                      int *pivot, int *result) {
-  *result = clapack_dgetri(CblasColMajor, num_rows, Mdata, stride, pivot);
-}
+	inline int clapack_Xtrtri(int num_rows, double *Mdata, MatrixIndexT stride) {
+		return  clapack_dtrtri(CblasColMajor, CblasUpper, CblasNonUnit, num_rows,
+			Mdata, stride);
+	}
+	//
+	inline void clapack_Xgetri(MatrixIndexT num_rows, float *Mdata, MatrixIndexT stride,
+		int *pivot, int *result) {
+		*result = clapack_sgetri(CblasColMajor, num_rows, Mdata, stride, pivot);
+	}
+	inline void clapack_Xgetri(MatrixIndexT num_rows, double *Mdata, MatrixIndexT stride,
+		int *pivot, int *result) {
+		*result = clapack_dgetri(CblasColMajor, num_rows, Mdata, stride, pivot);
+	}
 #endif
+#else  // esle WINDOWS_ARM
 
+
+
+
+	inline void cblas_Xcopy(const int N, const float *X, const int incX, float *Y,
+		const int incY) {
+		cblas_scopy(&N, X, &incX, Y, &incY);
+	}
+
+	inline void cblas_Xcopy(const int N, const double *X, const int incX, double *Y,
+		const int incY) {
+		cblas_dcopy(&N, X, &incX, Y, &incY);
+	}
+
+
+	inline float cblas_Xasum(const int N, const float *X, const int incX) {
+		return cblas_sasum(&N, X, &incX);
+	}
+
+	inline double cblas_Xasum(const int N, const double *X, const int incX) {
+		return cblas_dasum(&N, X, &incX);
+	}
+
+	inline void cblas_Xrot(const int N, float *X, const int incX, float *Y,
+		const int incY, const float c, const float s) {
+		cblas_srot(&N, X, &incX, Y, &incY, &c, &s);
+	}
+	inline void cblas_Xrot(const int N, double *X, const int incX, double *Y,
+		const int incY, const double c, const double s) {
+		cblas_drot(&N, X, &incX, Y, &incY, &c, &s);
+	}
+	inline float cblas_Xdot(const int N, const float *const X,
+		const int incX, const float *const Y,
+		const int incY) {
+		return cblas_sdot(&N, X, &incX, Y, &incY);
+	}
+	inline double cblas_Xdot(const int N, const double *const X,
+		const int incX, const double *const Y,
+		const int incY) {
+		return cblas_ddot(&N, X, &incX, Y, &incY);
+	}
+	inline void cblas_Xaxpy(const int N, const float alpha, const float *X,
+		const int incX, float *Y, const int incY) {
+		cblas_saxpy(&N, &alpha, X, &incX, Y, &incY);
+	}
+	inline void cblas_Xaxpy(const int N, const double alpha, const double *X,
+		const int incX, double *Y, const int incY) {
+		cblas_daxpy(&N, &alpha, X, &incX, Y, &incY);
+	}
+	inline void cblas_Xscal(const int N, const float alpha, float *data,
+		const int inc) {
+		cblas_sscal(&N, &alpha, data, &inc);
+	}
+	inline void cblas_Xscal(const int N, const double alpha, double *data,
+		const int inc) {
+		cblas_dscal(&N, &alpha, data, &inc);
+	}
+	inline void cblas_Xspmv(const float alpha, const int num_rows, const float *Mdata,
+		const float *v, const int v_inc,
+		const float beta, float *y, const int y_inc) {
+		char UPLO_wrap = CblasLower;
+		cblas_sspmv(&UPLO_wrap, &num_rows, &alpha, Mdata, v, &v_inc, &beta, y, &y_inc);
+	}
+	inline void cblas_Xspmv(const double alpha, const int num_rows, const double *Mdata,
+		const double *v, const int v_inc,
+		const double beta, double *y, const int y_inc) {
+		char UPLO_wrap = CblasLower;
+		cblas_dspmv(&UPLO_wrap, &num_rows, &alpha, Mdata, v, &v_inc, &beta, y, &y_inc);
+	}
+	inline void cblas_Xtpmv(MatrixTransposeType trans, const float *Mdata,
+		const int num_rows, float *y, const int y_inc) {
+		char UPLO_wrap = CblasLower;
+		char TRANSPOSE_wrap = trans;
+		char DIAG_wrap = CblasNonUnit;
+		cblas_stpmv(&UPLO_wrap, &TRANSPOSE_wrap,
+			&DIAG_wrap, &num_rows, Mdata, y, &y_inc);
+	}
+	inline void cblas_Xtpmv(MatrixTransposeType trans, const double *Mdata,
+		const int num_rows, double *y, const int y_inc) {
+		char UPLO_wrap = CblasLower;
+		char TRANSPOSE_wrap = trans;
+		char DIAG_wrap = CblasNonUnit;
+		cblas_dtpmv(&UPLO_wrap, &TRANSPOSE_wrap,
+			&DIAG_wrap, &num_rows, Mdata, y, &y_inc);
+	}
+
+
+	inline void cblas_Xtpsv(MatrixTransposeType trans, const float *Mdata,
+		const int num_rows, float *y, const int y_inc) {
+		char UPLO_wrap = CblasLower;
+		char TRANSPOSE_wrap = trans;
+		char DIAG_wrap = CblasNonUnit;
+		cblas_stpsv(&UPLO_wrap, &TRANSPOSE_wrap,
+			&DIAG_wrap, &num_rows, Mdata, y, &y_inc);
+	}
+	inline void cblas_Xtpsv(MatrixTransposeType trans, const double *Mdata,
+		const int num_rows, double *y, const int y_inc) {
+		char UPLO_wrap = CblasLower;
+		char TRANSPOSE_wrap = trans;
+		char DIAG_wrap = CblasNonUnit;
+		cblas_dtpsv(&UPLO_wrap, &TRANSPOSE_wrap,
+			&DIAG_wrap, &num_rows, Mdata, y, &y_inc);
+	}
+
+	// x = alpha * M * y + beta * x
+	inline void cblas_Xspmv(MatrixIndexT dim, float alpha, const float *Mdata,
+		const float *ydata, MatrixIndexT ystride,
+		float beta, float *xdata, MatrixIndexT xstride) {
+		char UPLO_wrap = CblasLower;
+		cblas_sspmv(&UPLO_wrap, &dim, &alpha, Mdata,
+			ydata, &ystride, &beta, xdata, &xstride);
+	}
+	inline void cblas_Xspmv(MatrixIndexT dim, double alpha, const double *Mdata,
+		const double *ydata, MatrixIndexT ystride,
+		double beta, double *xdata, MatrixIndexT xstride) {
+		char UPLO_wrap = CblasLower;
+		cblas_dspmv(&UPLO_wrap, &dim, &alpha, Mdata,
+			ydata, &ystride, &beta, xdata, &xstride);
+	}
+
+	// Implements  A += alpha * (x y'  + y x'); A is symmetric matrix.
+	inline void cblas_Xspr2(MatrixIndexT dim, float alpha, const float *Xdata,
+		MatrixIndexT incX, const float *Ydata, MatrixIndexT incY,
+		float *Adata) {
+		char UPLO_wrap = CblasLower;
+		cblas_sspr2(&UPLO_wrap, &dim, &alpha, Xdata,
+			&incX, Ydata, &incY, Adata);
+	}
+	inline void cblas_Xspr2(MatrixIndexT dim, double alpha, const double *Xdata,
+		MatrixIndexT incX, const double *Ydata, MatrixIndexT incY,
+		double *Adata) {
+		char UPLO_wrap = CblasLower;
+		cblas_dspr2(&UPLO_wrap, &dim, &alpha, Xdata,
+			&incX, Ydata, &incY, Adata);
+	}
+
+	// Implements  A += alpha * (x x'); A is symmetric matrix.
+	inline void cblas_Xspr(MatrixIndexT dim, float alpha, const float *Xdata,
+		MatrixIndexT incX, float *Adata) {
+		char UPLO_wrap = CblasLower;
+		cblas_sspr(&UPLO_wrap, &dim, &alpha, Xdata, &incX, Adata);
+	}
+	inline void cblas_Xspr(MatrixIndexT dim, double alpha, const double *Xdata,
+		MatrixIndexT incX, double *Adata) {
+		char UPLO_wrap = CblasLower;
+		cblas_dspr(&UPLO_wrap, &dim, &alpha, Xdata, &incX, Adata);
+	}
+
+	// sgemv,dgemv: y = alpha M x + beta y.
+	inline void cblas_Xgemv(MatrixTransposeType trans, MatrixIndexT num_rows,
+		MatrixIndexT num_cols, float alpha, const float *Mdata,
+		MatrixIndexT stride, const float *xdata,
+		MatrixIndexT incX, float beta, float *ydata, MatrixIndexT incY) {
+		char TRANSPOSE_wrap = trans;
+		cblas_sgemv(&TRANSPOSE_wrap, &num_rows,
+			&num_cols, &alpha, Mdata, &stride, xdata, &incX, &beta, ydata, &incY);
+	}
+	inline void cblas_Xgemv(MatrixTransposeType trans, MatrixIndexT num_rows,
+		MatrixIndexT num_cols, double alpha, const double *Mdata,
+		MatrixIndexT stride, const double *xdata,
+		MatrixIndexT incX, double beta, double *ydata, MatrixIndexT incY) {
+		char TRANSPOSE_wrap = trans;
+		cblas_dgemv(&TRANSPOSE_wrap, &num_rows,
+			&num_cols, &alpha, Mdata, &stride, xdata, &incX, &beta, ydata, &incY);
+	}
+
+	// sgbmv, dgmmv: y = alpha M x +  + beta * y.
+	inline void cblas_Xgbmv(MatrixTransposeType trans, MatrixIndexT num_rows,
+		MatrixIndexT num_cols, MatrixIndexT num_below,
+		MatrixIndexT num_above, float alpha, const float *Mdata,
+		MatrixIndexT stride, const float *xdata,
+		MatrixIndexT incX, float beta, float *ydata, MatrixIndexT incY) {
+		char TRANSPOSE_wrap = trans;
+		cblas_sgbmv(&TRANSPOSE_wrap, &num_rows,
+			&num_cols, &num_below, &num_above, &alpha, Mdata, &stride, xdata,
+			&incX, &beta, ydata, &incY);
+	}
+	inline void cblas_Xgbmv(MatrixTransposeType trans, MatrixIndexT num_rows,
+		MatrixIndexT num_cols, MatrixIndexT num_below,
+		MatrixIndexT num_above, double alpha, const double *Mdata,
+		MatrixIndexT stride, const double *xdata,
+		MatrixIndexT incX, double beta, double *ydata, MatrixIndexT incY) {
+		char TRANSPOSE_wrap = trans;
+		cblas_dgbmv(&TRANSPOSE_wrap, &num_rows,
+			&num_cols, &num_below, &num_above, &alpha, Mdata, &stride, xdata,
+			&incX, &beta, ydata, &incY);
+	}
+
+
+	template<typename Real>
+	inline void Xgemv_sparsevec(MatrixTransposeType trans, MatrixIndexT num_rows,
+		MatrixIndexT num_cols, Real alpha, const Real *Mdata,
+		MatrixIndexT stride, const Real *xdata,
+		MatrixIndexT incX, Real beta, Real *ydata,
+		MatrixIndexT incY) {
+		if (trans == kNoTrans) {
+			if (beta != 1.0) cblas_Xscal(num_rows, beta, ydata, incY);
+			for (MatrixIndexT i = 0; i < num_cols; i++) {
+				Real x_i = xdata[i * incX];
+				if (x_i == 0.0) continue;
+				// Add to ydata, the i'th column of M, times alpha * x_i
+				cblas_Xaxpy(num_rows, x_i * alpha, Mdata + i, stride, ydata, incY);
+			}
+		}
+		else {
+			if (beta != 1.0) cblas_Xscal(num_cols, beta, ydata, incY);
+			for (MatrixIndexT i = 0; i < num_rows; i++) {
+				Real x_i = xdata[i * incX];
+				if (x_i == 0.0) continue;
+				// Add to ydata, the i'th row of M, times alpha * x_i
+				cblas_Xaxpy(num_cols, x_i * alpha,
+					Mdata + (i * stride), 1, ydata, incY);
+			}
+		}
+	}
+
+	inline void cblas_Xgemm(const float alpha,
+		MatrixTransposeType transA,
+		const float *Adata,
+		MatrixIndexT a_num_rows, MatrixIndexT a_num_cols, MatrixIndexT a_stride,
+		MatrixTransposeType transB,
+		const float *Bdata, MatrixIndexT b_stride,
+		const float beta,
+		float *Mdata,
+		MatrixIndexT num_rows, MatrixIndexT num_cols, MatrixIndexT stride) {
+		char TRANSOPSE_wrapA = transA;
+		char TRANSOPSE_wrapB = transB;
+		cblas_sgemm(&TRANSOPSE_wrapA,
+			&TRANSOPSE_wrapB,
+			&num_rows, &num_cols, &(int)(transA == kNoTrans ? a_num_cols : a_num_rows),
+			&alpha, Adata, &a_stride, Bdata, &b_stride,
+			&beta, Mdata, &stride);
+	}
+	inline void cblas_Xgemm(const double alpha,
+		MatrixTransposeType transA,
+		const double *Adata,
+		MatrixIndexT a_num_rows, MatrixIndexT a_num_cols, MatrixIndexT a_stride,
+		MatrixTransposeType transB,
+		const double *Bdata, MatrixIndexT b_stride,
+		const double beta,
+		double *Mdata,
+		MatrixIndexT num_rows, MatrixIndexT num_cols, MatrixIndexT stride) {
+		char TRANSOPSE_wrapA = transA;
+		char TRANSOPSE_wrapB = transB;
+		cblas_dgemm(&TRANSOPSE_wrapA,
+			&TRANSOPSE_wrapB,
+			&num_rows, &num_cols, &(int)(transA == kNoTrans ? a_num_cols : a_num_rows),
+			&alpha, Adata, &a_stride, Bdata, &b_stride,
+			&beta, Mdata, &stride);
+	}
+
+
+	inline void cblas_Xsymm(const float alpha,
+		MatrixIndexT sz,
+		const float *Adata, MatrixIndexT a_stride,
+		const float *Bdata, MatrixIndexT b_stride,
+		const float beta,
+		float *Mdata, MatrixIndexT stride) {
+		char SIDE_wrap = CblasLeft;
+		char UPLO_wrap = CblasLower;
+		cblas_ssymm(&SIDE_wrap, &UPLO_wrap, &sz, &sz, &alpha, Adata,
+			&a_stride, Bdata, &b_stride, &beta, Mdata, &stride);
+	}
+	inline void cblas_Xsymm(const double alpha,
+		MatrixIndexT sz,
+		const double *Adata, MatrixIndexT a_stride,
+		const double *Bdata, MatrixIndexT b_stride,
+		const double beta,
+		double *Mdata, MatrixIndexT stride) {
+		char SIDE_wrap = CblasLeft;
+		char UPLO_wrap = CblasLower;
+		cblas_dsymm(&SIDE_wrap, &UPLO_wrap, &sz, &sz, &alpha, Adata,
+			&a_stride, Bdata, &b_stride, &beta, Mdata, &stride);
+	}
+	// ger: M += alpha x y^T.
+	inline void cblas_Xger(MatrixIndexT num_rows, MatrixIndexT num_cols, float alpha,
+		const float *xdata, MatrixIndexT incX, const float *ydata,
+		MatrixIndexT incY, float *Mdata, MatrixIndexT stride) {
+		cblas_sger(&(int)num_rows, &(int)num_cols, &alpha, xdata, &(int)incX, ydata, &(int)incY,
+			Mdata, &(int)stride);
+	}
+	inline void cblas_Xger(MatrixIndexT num_rows, MatrixIndexT num_cols, double alpha,
+		const double *xdata, MatrixIndexT incX, const double *ydata,
+		MatrixIndexT incY, double *Mdata, MatrixIndexT stride) {
+		cblas_dger(&(int)num_rows, &(int)num_cols, &alpha, xdata, &(int)incX, ydata, &(int)incY,
+			Mdata, &(int)stride);
+	}
+
+	// syrk: symmetric rank-k update.
+	// if trans==kNoTrans, then C = alpha A A^T + beta C
+	// else C = alpha A^T A + beta C.
+	// note: dim_c is dim(C), other_dim_a is the "other" dimension of A, i.e.
+	// num-cols(A) if kNoTrans, or num-rows(A) if kTrans.
+	// We only need the row-major and lower-triangular option of this, and this
+	// is hard-coded.
+	inline void cblas_Xsyrk(
+		const MatrixTransposeType trans, const MatrixIndexT dim_c,
+		const MatrixIndexT other_dim_a, const float alpha, const float *A,
+		const MatrixIndexT a_stride, const float beta, float *C,
+		const MatrixIndexT c_stride) {
+		char UPLO_wrap = CblasLower;
+		char TRANSPOSE_wrap = trans;
+		cblas_ssyrk(&UPLO_wrap, &TRANSPOSE_wrap,
+			&dim_c, &other_dim_a, &alpha, A, &a_stride, &beta, C, &c_stride);
+	}
+
+	inline void cblas_Xsyrk(
+		const MatrixTransposeType trans, const MatrixIndexT dim_c,
+		const MatrixIndexT other_dim_a, const double alpha, const double *A,
+		const MatrixIndexT a_stride, const double beta, double *C,
+		const MatrixIndexT c_stride) {
+		char UPLO_wrap = CblasLower;
+		char TRANSPOSE_wrap = trans;
+		cblas_dsyrk(&UPLO_wrap, &TRANSPOSE_wrap,
+			&dim_c, &other_dim_a, &alpha, A, &a_stride, &beta, C, &c_stride);
+	}
+
+	/// matrix-vector multiply using a banded matrix; we always call this
+	/// with b = 1 meaning we're multiplying by a diagonal matrix.  This is used for
+	/// elementwise multiplication.  We miss some of the arguments out of this
+	/// wrapper.
+	inline void cblas_Xsbmv1(
+		const MatrixIndexT dim,
+		const double *A,
+		const double alpha,
+		const double *x,
+		const double beta,
+		double *y) {
+		char UPLO_wrap = CblasLower;
+		int incX = 1;
+		int incY = 1;
+		int lda = 1;
+		cblas_dsbmv(&UPLO_wrap, &dim, 0, &alpha, A,
+			&incX, x, &incY, &beta, y, &lda);
+	}
+
+	inline void cblas_Xsbmv1(
+		const MatrixIndexT dim,
+		const float *A,
+		const float alpha,
+		const float *x,
+		const float beta,
+		float *y) {
+		char UPLO_wrap = CblasLower;
+		int incX = 1;
+		int incY = 1;
+		int lda = 1;
+		cblas_ssbmv(&UPLO_wrap, &dim, 0, &alpha, A,
+			&incX, x, &incY, &beta, y, &lda);
+	}
+
+
+	/// This is not really a wrapper for CBLAS as CBLAS does not have this; in future we could
+	/// extend this somehow.
+	inline void mul_elements(
+		const MatrixIndexT dim,
+		const double *a,
+		double *b) { // does b *= a, elementwise.
+		double c1, c2, c3, c4;
+		MatrixIndexT i;
+		for (i = 0; i + 4 <= dim; i += 4) {
+			c1 = a[i] * b[i];
+			c2 = a[i + 1] * b[i + 1];
+			c3 = a[i + 2] * b[i + 2];
+			c4 = a[i + 3] * b[i + 3];
+			b[i] = c1;
+			b[i + 1] = c2;
+			b[i + 2] = c3;
+			b[i + 3] = c4;
+		}
+		for (; i < dim; i++)
+			b[i] *= a[i];
+	}
+
+	inline void mul_elements(
+		const MatrixIndexT dim,
+		const float *a,
+		float *b) { // does b *= a, elementwise.
+		float c1, c2, c3, c4;
+		MatrixIndexT i;
+		for (i = 0; i + 4 <= dim; i += 4) {
+			c1 = a[i] * b[i];
+			c2 = a[i + 1] * b[i + 1];
+			c3 = a[i + 2] * b[i + 2];
+			c4 = a[i + 3] * b[i + 3];
+			b[i] = c1;
+			b[i + 1] = c2;
+			b[i + 2] = c3;
+			b[i + 3] = c4;
+		}
+		for (; i < dim; i++)
+			b[i] *= a[i];
+	}
+
+
+
+	// add clapack here
+	inline void clapack_Xtptri(KaldiBlasInt *num_rows, float *Mdata, KaldiBlasInt *result) {
+		stptri_(const_cast<char *>("U"), const_cast<char *>("N"), num_rows, Mdata, result);
+	}
+	inline void clapack_Xtptri(KaldiBlasInt *num_rows, double *Mdata, KaldiBlasInt *result) {
+		dtptri_(const_cast<char *>("U"), const_cast<char *>("N"), num_rows, Mdata, result);
+	}
+	// 
+	inline void clapack_Xgetrf2(KaldiBlasInt *num_rows, KaldiBlasInt *num_cols,
+		float *Mdata, KaldiBlasInt *stride, KaldiBlasInt *pivot,
+		KaldiBlasInt *result) {
+		sgetrf_(num_rows, num_cols, Mdata, stride, pivot, result);
+	}
+	inline void clapack_Xgetrf2(KaldiBlasInt *num_rows, KaldiBlasInt *num_cols,
+		double *Mdata, KaldiBlasInt *stride, KaldiBlasInt *pivot,
+		KaldiBlasInt *result) {
+		dgetrf_(num_rows, num_cols, Mdata, stride, pivot, result);
+	}
+
+	// 
+	inline void clapack_Xgetri2(KaldiBlasInt *num_rows, float *Mdata, KaldiBlasInt *stride,
+		KaldiBlasInt *pivot, float *p_work,
+		KaldiBlasInt *l_work, KaldiBlasInt *result) {
+		sgetri_(num_rows, Mdata, stride, pivot, p_work, l_work, result);
+	}
+	inline void clapack_Xgetri2(KaldiBlasInt *num_rows, double *Mdata, KaldiBlasInt *stride,
+		KaldiBlasInt *pivot, double *p_work,
+		KaldiBlasInt *l_work, KaldiBlasInt *result) {
+		dgetri_(num_rows, Mdata, stride, pivot, p_work, l_work, result);
+	}
+	//
+	inline void clapack_Xgesvd(char *v, char *u, KaldiBlasInt *num_cols,
+		KaldiBlasInt *num_rows, float *Mdata, KaldiBlasInt *stride,
+		float *sv, float *Vdata, KaldiBlasInt *vstride,
+		float *Udata, KaldiBlasInt *ustride, float *p_work,
+		KaldiBlasInt *l_work, KaldiBlasInt *result) {
+		sgesvd_(v, u,
+			num_cols, num_rows, Mdata, stride,
+			sv, Vdata, vstride, Udata, ustride,
+			p_work, l_work, result);
+	}
+	inline void clapack_Xgesvd(char *v, char *u, KaldiBlasInt *num_cols,
+		KaldiBlasInt *num_rows, double *Mdata, KaldiBlasInt *stride,
+		double *sv, double *Vdata, KaldiBlasInt *vstride,
+		double *Udata, KaldiBlasInt *ustride, double *p_work,
+		KaldiBlasInt *l_work, KaldiBlasInt *result) {
+		dgesvd_(v, u,
+			num_cols, num_rows, Mdata, stride,
+			sv, Vdata, vstride, Udata, ustride,
+			p_work, l_work, result);
+	}
+	//
+	void inline clapack_Xsptri(KaldiBlasInt *num_rows, float *Mdata,
+		KaldiBlasInt *ipiv, float *work, KaldiBlasInt *result) {
+		ssptri_(const_cast<char *>("U"), num_rows, Mdata, ipiv, work, result);
+	}
+	void inline clapack_Xsptri(KaldiBlasInt *num_rows, double *Mdata,
+		KaldiBlasInt *ipiv, double *work, KaldiBlasInt *result) {
+		dsptri_(const_cast<char *>("U"), num_rows, Mdata, ipiv, work, result);
+	}
+	//
+	void inline clapack_Xsptrf(KaldiBlasInt *num_rows, float *Mdata,
+		KaldiBlasInt *ipiv, KaldiBlasInt *result) {
+		ssptrf_(const_cast<char *>("U"), num_rows, Mdata, ipiv, result);
+	}
+	void inline clapack_Xsptrf(KaldiBlasInt *num_rows, double *Mdata,
+		KaldiBlasInt *ipiv, KaldiBlasInt *result) {
+		dsptrf_(const_cast<char *>("U"), num_rows, Mdata, ipiv, result);
+	}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+#endif // endif WINDOWS_ARM
 }
 // namespace kaldi
 

--- a/src/matrix/kaldi-matrix.cc
+++ b/src/matrix/kaldi-matrix.cc
@@ -756,8 +756,8 @@ void MatrixBase<float>::CopyFromSp(const SpMatrix<float> & M) {
   const float *Mdata = M.Data();
   float *row_data = data_, *col_data = data_;
   for (MatrixIndexT i = 0; i < num_rows; i++) {
-    cblas_scopy(i+1, Mdata, 1, row_data, 1); // copy to the row.
-    cblas_scopy(i, Mdata, 1, col_data, stride); // copy to the column.
+    cblas_Xcopy(i+1, Mdata, 1, row_data, 1); // copy to the row.
+    cblas_Xcopy(i, Mdata, 1, col_data, stride); // copy to the column.
     Mdata += i+1;
     row_data += stride;
     col_data += 1;
@@ -773,8 +773,8 @@ void MatrixBase<double>::CopyFromSp(const SpMatrix<double> & M) {
   const double *Mdata = M.Data();
   double *row_data = data_, *col_data = data_;
   for (MatrixIndexT i = 0; i < num_rows; i++) {
-    cblas_dcopy(i+1, Mdata, 1, row_data, 1); // copy to the row.
-    cblas_dcopy(i, Mdata, 1, col_data, stride); // copy to the column.
+    cblas_Xcopy(i+1, Mdata, 1, row_data, 1); // copy to the row.
+    cblas_Xcopy(i, Mdata, 1, col_data, stride); // copy to the column.
     Mdata += i+1;
     row_data += stride;
     col_data += 1;

--- a/src/thread/kaldi-barrier.cc
+++ b/src/thread/kaldi-barrier.cc
@@ -18,7 +18,6 @@
 // limitations under the License.
 
 
-#include <pthread.h>
 #include "base/kaldi-error.h"
 #include "thread/kaldi-barrier.h"
 

--- a/src/thread/kaldi-mutex.cc
+++ b/src/thread/kaldi-mutex.cc
@@ -18,7 +18,6 @@
 // limitations under the License.
 
 
-#include <pthread.h>
 #include <cerrno>
 #include <string.h>
 #include "base/kaldi-error.h"

--- a/tools/CLAPACK/cblas.h
+++ b/tools/CLAPACK/cblas.h
@@ -1,596 +1,606 @@
 #ifndef CBLAS_H
 
 #ifndef CBLAS_ENUM_DEFINED_H
-   #define CBLAS_ENUM_DEFINED_H
-   enum CBLAS_ORDER {CblasRowMajor=101, CblasColMajor=102 };
-   enum CBLAS_TRANSPOSE {CblasNoTrans=111, CblasTrans=112, CblasConjTrans=113,
-                         AtlasConj=114};
-   enum CBLAS_UPLO  {CblasUpper=121, CblasLower=122};
-   enum CBLAS_DIAG  {CblasNonUnit=131, CblasUnit=132};
-   enum CBLAS_SIDE  {CblasLeft=141, CblasRight=142};
+#define CBLAS_ENUM_DEFINED_H
+enum CBLAS_ORDER { CblasRowMajor = 101, CblasColMajor = 102 };
+enum CBLAS_TRANSPOSE {
+	CblasNoTrans = 110, CblasTrans = 116, CblasConjTrans = 99};
+enum CBLAS_UPLO { CblasUpper = 121, CblasLower = 122 };
+enum CBLAS_DIAG { CblasNonUnit = 131, CblasUnit = 132 };
+enum CBLAS_SIDE { CblasLeft = 141, CblasRight = 142 };
 #endif
 
 #ifndef CBLAS_ENUM_ONLY
 #define CBLAS_H
 #define CBLAS_INDEX int
 
-int cblas_errprn(int ierr, int info, char *form, ...);
+#ifdef __cplusplus 	
+extern "C" {
+#endif	
 
-/*
- * ===========================================================================
- * Prototypes for level 1 BLAS functions (complex are recast as routines)
- * ===========================================================================
- */
-float  cblas_sdsdot(const int N, const float alpha, const float *X,
-                    const int incX, const float *Y, const int incY);
-double cblas_dsdot(const int N, const float *X, const int incX, const float *Y,
-                   const int incY);
-float  cblas_sdot(const int N, const float  *X, const int incX,
-                  const float  *Y, const int incY);
-double cblas_ddot(const int N, const double *X, const int incX,
-                  const double *Y, const int incY);
-/*
- * Functions having prefixes Z and C only
- */
-void   cblas_cdotu_sub(const int N, const void *X, const int incX,
-                       const void *Y, const int incY, void *dotu);
-void   cblas_cdotc_sub(const int N, const void *X, const int incX,
-                       const void *Y, const int incY, void *dotc);
+	int cblas_errprn(int *ierr, int *info, char *form, ...);
 
-void   cblas_zdotu_sub(const int N, const void *X, const int incX,
-                       const void *Y, const int incY, void *dotu);
-void   cblas_zdotc_sub(const int N, const void *X, const int incX,
-                       const void *Y, const int incY, void *dotc);
+	/*
+	* ===========================================================================
+	* Prototypes for level 1 BLAS functions (complex are recast as routines)
+	* ===========================================================================
+	*/
+	float  cblas_sdsdot(const int *N, const float *alpha, const float *X,
+		const int *incX, const float *Y, const int *incY);
+	double cblas_dsdot(const int *N, const float *X, const int *incX, const float *Y,
+		const int *incY);
+	float  cblas_sdot(const int *N, const float  *X, const int *incX,
+		const float  *Y, const int *incY);
+	double cblas_ddot(const int *N, const double *X, const int *incX,
+		const double *Y, const int *incY);
+	/*
+	* Functions having prefixes Z and C only
+	*/
+	void   cblas_cdotu_sub(const int *N, const void *X, const int *incX,
+		const void *Y, const int *incY, void *dotu);
+	void   cblas_cdotc_sub(const int *N, const void *X, const int *incX,
+		const void *Y, const int *incY, void *dotc);
 
-
-/*
- * Functions having prefixes S D SC DZ
- */
-float  cblas_snrm2(const int N, const float *X, const int incX);
-float  cblas_sasum(const int N, const float *X, const int incX);
-
-double cblas_dnrm2(const int N, const double *X, const int incX);
-double cblas_dasum(const int N, const double *X, const int incX);
-
-float  cblas_scnrm2(const int N, const void *X, const int incX);
-float  cblas_scasum(const int N, const void *X, const int incX);
-
-double cblas_dznrm2(const int N, const void *X, const int incX);
-double cblas_dzasum(const int N, const void *X, const int incX);
+	void   cblas_zdotu_sub(const int *N, const void *X, const int *incX,
+		const void *Y, const int *incY, void *dotu);
+	void   cblas_zdotc_sub(const int *N, const void *X, const int *incX,
+		const void *Y, const int *incY, void *dotc);
 
 
-/*
- * Functions having standard 4 prefixes (S D C Z)
- */
-CBLAS_INDEX cblas_isamax(const int N, const float  *X, const int incX);
-CBLAS_INDEX cblas_idamax(const int N, const double *X, const int incX);
-CBLAS_INDEX cblas_icamax(const int N, const void   *X, const int incX);
-CBLAS_INDEX cblas_izamax(const int N, const void   *X, const int incX);
+	/*
+	* Functions having prefixes S D SC DZ
+	*/
+	float  cblas_snrm2(const int *N, const float *X, const int *incX);
+	float  cblas_sasum(const int *N, const float *X, const int *incX);
 
-/*
- * ===========================================================================
- * Prototypes for level 1 BLAS routines
- * ===========================================================================
- */
+	double cblas_dnrm2(const int *N, const double *X, const int *incX);
+	double cblas_dasum(const int *N, const double *X, const int *incX);
 
-/*
- * Routines with standard 4 prefixes (s, d, c, z)
- */
-void cblas_sswap(const int N, float *X, const int incX,
-                 float *Y, const int incY);
-void cblas_scopy(const int N, const float *X, const int incX,
-                 float *Y, const int incY);
-void cblas_saxpy(const int N, const float alpha, const float *X,
-                 const int incX, float *Y, const int incY);
-void catlas_saxpby(const int N, const float alpha, const float *X,
-                  const int incX, const float beta, float *Y, const int incY);
-void catlas_sset
-   (const int N, const float alpha, float *X, const int incX);
+	float  cblas_scnrm2(const int *N, const void *X, const int *incX);
+	float  cblas_scasum(const int *N, const void *X, const int *incX);
 
-void cblas_dswap(const int N, double *X, const int incX,
-                 double *Y, const int incY);
-void cblas_dcopy(const int N, const double *X, const int incX,
-                 double *Y, const int incY);
-void cblas_daxpy(const int N, const double alpha, const double *X,
-                 const int incX, double *Y, const int incY);
-void catlas_daxpby(const int N, const double alpha, const double *X,
-                  const int incX, const double beta, double *Y, const int incY);
-void catlas_dset
-   (const int N, const double alpha, double *X, const int incX);
-
-void cblas_cswap(const int N, void *X, const int incX,
-                 void *Y, const int incY);
-void cblas_ccopy(const int N, const void *X, const int incX,
-                 void *Y, const int incY);
-void cblas_caxpy(const int N, const void *alpha, const void *X,
-                 const int incX, void *Y, const int incY);
-void catlas_caxpby(const int N, const void *alpha, const void *X,
-                  const int incX, const void *beta, void *Y, const int incY);
-void catlas_cset
-   (const int N, const void *alpha, void *X, const int incX);
-
-void cblas_zswap(const int N, void *X, const int incX,
-                 void *Y, const int incY);
-void cblas_zcopy(const int N, const void *X, const int incX,
-                 void *Y, const int incY);
-void cblas_zaxpy(const int N, const void *alpha, const void *X,
-                 const int incX, void *Y, const int incY);
-void catlas_zaxpby(const int N, const void *alpha, const void *X,
-                  const int incX, const void *beta, void *Y, const int incY);
-void catlas_zset
-   (const int N, const void *alpha, void *X, const int incX);
+	double cblas_dznrm2(const int *N, const void *X, const int *incX);
+	double cblas_dzasum(const int *N, const void *X, const int *incX);
 
 
-/*
- * Routines with S and D prefix only
- */
-void cblas_srotg(float *a, float *b, float *c, float *s);
-void cblas_srotmg(float *d1, float *d2, float *b1, const float b2, float *P);
-void cblas_srot(const int N, float *X, const int incX,
-                float *Y, const int incY, const float c, const float s);
-void cblas_srotm(const int N, float *X, const int incX,
-                float *Y, const int incY, const float *P);
+	/*
+	* Functions having standard 4 prefixes (S D C Z)
+	*/
+	CBLAS_INDEX cblas_isamax(const int *N, const float  *X, const int *incX);
+	CBLAS_INDEX cblas_idamax(const int *N, const double *X, const int *incX);
+	CBLAS_INDEX cblas_icamax(const int *N, const void   *X, const int *incX);
+	CBLAS_INDEX cblas_izamax(const int *N, const void   *X, const int *incX);
 
-void cblas_drotg(double *a, double *b, double *c, double *s);
-void cblas_drotmg(double *d1, double *d2, double *b1, const double b2, double *P);
-void cblas_drot(const int N, double *X, const int incX,
-                double *Y, const int incY, const double c, const double s);
-void cblas_drotm(const int N, double *X, const int incX,
-                double *Y, const int incY, const double *P);
+	/*
+	* ===========================================================================
+	* Prototypes for level 1 BLAS routines
+	* ===========================================================================
+	*/
 
+	/*
+	* Routines with standard 4 prefixes (s, d, *c, z)
+	*/
+	void cblas_sswap(const int *N, float *X, const int *incX,
+		float *Y, const int *incY);
+	void cblas_scopy(const int *N, const float *X, const int *incX,
+		float *Y, const int *incY);
+	void cblas_saxpy(const int *N, const float *alpha, const float *X,
+		const int *incX, float *Y, const int *incY);
+	void catlas_saxpby(const int *N, const float *alpha, const float *X,
+		const int *incX, const float *beta, float *Y, const int *incY);
+	void catlas_sset
+	(const int *N, const float *alpha, float *X, const int *incX);
 
-/*
- * Routines with S D C Z CS and ZD prefixes
- */
-void cblas_sscal(const int N, const float alpha, float *X, const int incX);
-void cblas_dscal(const int N, const double alpha, double *X, const int incX);
-void cblas_cscal(const int N, const void *alpha, void *X, const int incX);
-void cblas_zscal(const int N, const void *alpha, void *X, const int incX);
-void cblas_csscal(const int N, const float alpha, void *X, const int incX);
-void cblas_zdscal(const int N, const double alpha, void *X, const int incX);
+	void cblas_dswap(const int *N, double *X, const int *incX,
+		double *Y, const int *incY);
+	void cblas_dcopy(const int *N, const double *X, const int *incX,
+		double *Y, const int *incY);
+	void cblas_daxpy(const int *N, const double *alpha, const double *X,
+		const int *incX, double *Y, const int *incY);
+	void catlas_daxpby(const int *N, const double *alpha, const double *X,
+		const int *incX, const double *beta, double *Y, const int *incY);
+	void catlas_dset
+	(const int *N, const double *alpha, double *X, const int *incX);
 
-/*
- * Extra reference routines provided by ATLAS, but not mandated by the standard
- */
-void cblas_crotg(void *a, void *b, void *c, void *s);
-void cblas_zrotg(void *a, void *b, void *c, void *s);
-void cblas_csrot(const int N, void *X, const int incX, void *Y, const int incY,
-                 const float c, const float s);
-void cblas_zdrot(const int N, void *X, const int incX, void *Y, const int incY,
-                 const double c, const double s);
+	void cblas_cswap(const int *N, void *X, const int *incX,
+		void *Y, const int *incY);
+	void cblas_ccopy(const int *N, const void *X, const int *incX,
+		void *Y, const int *incY);
+	void cblas_caxpy(const int *N, const void *alpha, const void *X,
+		const int *incX, void *Y, const int *incY);
+	void catlas_caxpby(const int *N, const void *alpha, const void *X,
+		const int *incX, const void *beta, void *Y, const int *incY);
+	void catlas_cset
+	(const int *N, const void *alpha, void *X, const int *incX);
 
-/*
- * ===========================================================================
- * Prototypes for level 2 BLAS
- * ===========================================================================
- */
-
-/*
- * Routines with standard 4 prefixes (S, D, C, Z)
- */
-void cblas_sgemv(const enum CBLAS_ORDER Order,
-                 const enum CBLAS_TRANSPOSE TransA, const int M, const int N,
-                 const float alpha, const float *A, const int lda,
-                 const float *X, const int incX, const float beta,
-                 float *Y, const int incY);
-void cblas_sgbmv(const enum CBLAS_ORDER Order,
-                 const enum CBLAS_TRANSPOSE TransA, const int M, const int N,
-                 const int KL, const int KU, const float alpha,
-                 const float *A, const int lda, const float *X,
-                 const int incX, const float beta, float *Y, const int incY);
-void cblas_strmv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag,
-                 const int N, const float *A, const int lda,
-                 float *X, const int incX);
-void cblas_stbmv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag,
-                 const int N, const int K, const float *A, const int lda,
-                 float *X, const int incX);
-void cblas_stpmv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag,
-                 const int N, const float *Ap, float *X, const int incX);
-void cblas_strsv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag,
-                 const int N, const float *A, const int lda, float *X,
-                 const int incX);
-void cblas_stbsv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag,
-                 const int N, const int K, const float *A, const int lda,
-                 float *X, const int incX);
-void cblas_stpsv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag,
-                 const int N, const float *Ap, float *X, const int incX);
-
-void cblas_dgemv(const enum CBLAS_ORDER Order,
-                 const enum CBLAS_TRANSPOSE TransA, const int M, const int N,
-                 const double alpha, const double *A, const int lda,
-                 const double *X, const int incX, const double beta,
-                 double *Y, const int incY);
-void cblas_dgbmv(const enum CBLAS_ORDER Order,
-                 const enum CBLAS_TRANSPOSE TransA, const int M, const int N,
-                 const int KL, const int KU, const double alpha,
-                 const double *A, const int lda, const double *X,
-                 const int incX, const double beta, double *Y, const int incY);
-void cblas_dtrmv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag,
-                 const int N, const double *A, const int lda,
-                 double *X, const int incX);
-void cblas_dtbmv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag,
-                 const int N, const int K, const double *A, const int lda,
-                 double *X, const int incX);
-void cblas_dtpmv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag,
-                 const int N, const double *Ap, double *X, const int incX);
-void cblas_dtrsv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag,
-                 const int N, const double *A, const int lda, double *X,
-                 const int incX);
-void cblas_dtbsv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag,
-                 const int N, const int K, const double *A, const int lda,
-                 double *X, const int incX);
-void cblas_dtpsv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag,
-                 const int N, const double *Ap, double *X, const int incX);
-
-void cblas_cgemv(const enum CBLAS_ORDER Order,
-                 const enum CBLAS_TRANSPOSE TransA, const int M, const int N,
-                 const void *alpha, const void *A, const int lda,
-                 const void *X, const int incX, const void *beta,
-                 void *Y, const int incY);
-void cblas_cgbmv(const enum CBLAS_ORDER Order,
-                 const enum CBLAS_TRANSPOSE TransA, const int M, const int N,
-                 const int KL, const int KU, const void *alpha,
-                 const void *A, const int lda, const void *X,
-                 const int incX, const void *beta, void *Y, const int incY);
-void cblas_ctrmv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag,
-                 const int N, const void *A, const int lda,
-                 void *X, const int incX);
-void cblas_ctbmv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag,
-                 const int N, const int K, const void *A, const int lda,
-                 void *X, const int incX);
-void cblas_ctpmv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag,
-                 const int N, const void *Ap, void *X, const int incX);
-void cblas_ctrsv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag,
-                 const int N, const void *A, const int lda, void *X,
-                 const int incX);
-void cblas_ctbsv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag,
-                 const int N, const int K, const void *A, const int lda,
-                 void *X, const int incX);
-void cblas_ctpsv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag,
-                 const int N, const void *Ap, void *X, const int incX);
-
-void cblas_zgemv(const enum CBLAS_ORDER Order,
-                 const enum CBLAS_TRANSPOSE TransA, const int M, const int N,
-                 const void *alpha, const void *A, const int lda,
-                 const void *X, const int incX, const void *beta,
-                 void *Y, const int incY);
-void cblas_zgbmv(const enum CBLAS_ORDER Order,
-                 const enum CBLAS_TRANSPOSE TransA, const int M, const int N,
-                 const int KL, const int KU, const void *alpha,
-                 const void *A, const int lda, const void *X,
-                 const int incX, const void *beta, void *Y, const int incY);
-void cblas_ztrmv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag,
-                 const int N, const void *A, const int lda,
-                 void *X, const int incX);
-void cblas_ztbmv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag,
-                 const int N, const int K, const void *A, const int lda,
-                 void *X, const int incX);
-void cblas_ztpmv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag,
-                 const int N, const void *Ap, void *X, const int incX);
-void cblas_ztrsv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag,
-                 const int N, const void *A, const int lda, void *X,
-                 const int incX);
-void cblas_ztbsv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag,
-                 const int N, const int K, const void *A, const int lda,
-                 void *X, const int incX);
-void cblas_ztpsv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag,
-                 const int N, const void *Ap, void *X, const int incX);
+	void cblas_zswap(const int *N, void *X, const int *incX,
+		void *Y, const int *incY);
+	void cblas_zcopy(const int *N, const void *X, const int *incX,
+		void *Y, const int *incY);
+	void cblas_zaxpy(const int *N, const void *alpha, const void *X,
+		const int *incX, void *Y, const int *incY);
+	void catlas_zaxpby(const int *N, const void *alpha, const void *X,
+		const int *incX, const void *beta, void *Y, const int *incY);
+	void catlas_zset
+	(const int *N, const void *alpha, void *X, const int *incX);
 
 
-/*
- * Routines with S and D prefixes only
- */
-void cblas_ssymv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                 const int N, const float alpha, const float *A,
-                 const int lda, const float *X, const int incX,
-                 const float beta, float *Y, const int incY);
-void cblas_ssbmv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                 const int N, const int K, const float alpha, const float *A,
-                 const int lda, const float *X, const int incX,
-                 const float beta, float *Y, const int incY);
-void cblas_sspmv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                 const int N, const float alpha, const float *Ap,
-                 const float *X, const int incX,
-                 const float beta, float *Y, const int incY);
-void cblas_sger(const enum CBLAS_ORDER Order, const int M, const int N,
-                const float alpha, const float *X, const int incX,
-                const float *Y, const int incY, float *A, const int lda);
-void cblas_ssyr(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                const int N, const float alpha, const float *X,
-                const int incX, float *A, const int lda);
-void cblas_sspr(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                const int N, const float alpha, const float *X,
-                const int incX, float *Ap);
-void cblas_ssyr2(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                const int N, const float alpha, const float *X,
-                const int incX, const float *Y, const int incY, float *A,
-                const int lda);
-void cblas_sspr2(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                const int N, const float alpha, const float *X,
-                const int incX, const float *Y, const int incY, float *A);
+	/*
+	* Routines with S and D prefix only
+	*/
+	void cblas_srotg(float *a, float *b, float *c, float *s);
+	void cblas_srotmg(float *d1, float *d2, float *b1, const float *b2, float *P);
+	void cblas_srot(const int *N, float *X, const int *incX,
+		float *Y, const int *incY, const float *c, const float *s);
+	void cblas_srotm(const int *N, float *X, const int *incX,
+		float *Y, const int *incY, const float *P);
 
-void cblas_dsymv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                 const int N, const double alpha, const double *A,
-                 const int lda, const double *X, const int incX,
-                 const double beta, double *Y, const int incY);
-void cblas_dsbmv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                 const int N, const int K, const double alpha, const double *A,
-                 const int lda, const double *X, const int incX,
-                 const double beta, double *Y, const int incY);
-void cblas_dspmv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                 const int N, const double alpha, const double *Ap,
-                 const double *X, const int incX,
-                 const double beta, double *Y, const int incY);
-void cblas_dger(const enum CBLAS_ORDER Order, const int M, const int N,
-                const double alpha, const double *X, const int incX,
-                const double *Y, const int incY, double *A, const int lda);
-void cblas_dsyr(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                const int N, const double alpha, const double *X,
-                const int incX, double *A, const int lda);
-void cblas_dspr(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                const int N, const double alpha, const double *X,
-                const int incX, double *Ap);
-void cblas_dsyr2(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                const int N, const double alpha, const double *X,
-                const int incX, const double *Y, const int incY, double *A,
-                const int lda);
-void cblas_dspr2(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                const int N, const double alpha, const double *X,
-                const int incX, const double *Y, const int incY, double *A);
+	void cblas_drotg(double *a, double *b, double *c, double *s);
+	void cblas_drotmg(double *d1, double *d2, double *b1, const double *b2, double *P);
+	void cblas_drot(const int *N, double *X, const int *incX,
+		double *Y, const int *incY, const double *c, const double *s);
+	void cblas_drotm(const int *N, double *X, const int *incX,
+		double *Y, const int *incY, const double *P);
 
 
-/*
- * Routines with C and Z prefixes only
- */
-void cblas_chemv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                 const int N, const void *alpha, const void *A,
-                 const int lda, const void *X, const int incX,
-                 const void *beta, void *Y, const int incY);
-void cblas_chbmv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                 const int N, const int K, const void *alpha, const void *A,
-                 const int lda, const void *X, const int incX,
-                 const void *beta, void *Y, const int incY);
-void cblas_chpmv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                 const int N, const void *alpha, const void *Ap,
-                 const void *X, const int incX,
-                 const void *beta, void *Y, const int incY);
-void cblas_cgeru(const enum CBLAS_ORDER Order, const int M, const int N,
-                 const void *alpha, const void *X, const int incX,
-                 const void *Y, const int incY, void *A, const int lda);
-void cblas_cgerc(const enum CBLAS_ORDER Order, const int M, const int N,
-                 const void *alpha, const void *X, const int incX,
-                 const void *Y, const int incY, void *A, const int lda);
-void cblas_cher(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                const int N, const float alpha, const void *X, const int incX,
-                void *A, const int lda);
-void cblas_chpr(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                const int N, const float alpha, const void *X,
-                const int incX, void *A);
-void cblas_cher2(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo, const int N,
-                const void *alpha, const void *X, const int incX,
-                const void *Y, const int incY, void *A, const int lda);
-void cblas_chpr2(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo, const int N,
-                const void *alpha, const void *X, const int incX,
-                const void *Y, const int incY, void *Ap);
+	/*
+	* Routines with S D C Z CS and ZD prefixes
+	*/
+	void cblas_sscal(const int *N, const float *alpha, float *X, const int *incX);
+	void cblas_dscal(const int *N, const double *alpha, double *X, const int *incX);
+	void cblas_cscal(const int *N, const void *alpha, void *X, const int *incX);
+	void cblas_zscal(const int *N, const void *alpha, void *X, const int *incX);
+	void cblas_csscal(const int *N, const float *alpha, void *X, const int *incX);
+	void cblas_zdscal(const int *N, const double *alpha, void *X, const int *incX);
 
-void cblas_zhemv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                 const int N, const void *alpha, const void *A,
-                 const int lda, const void *X, const int incX,
-                 const void *beta, void *Y, const int incY);
-void cblas_zhbmv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                 const int N, const int K, const void *alpha, const void *A,
-                 const int lda, const void *X, const int incX,
-                 const void *beta, void *Y, const int incY);
-void cblas_zhpmv(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                 const int N, const void *alpha, const void *Ap,
-                 const void *X, const int incX,
-                 const void *beta, void *Y, const int incY);
-void cblas_zgeru(const enum CBLAS_ORDER Order, const int M, const int N,
-                 const void *alpha, const void *X, const int incX,
-                 const void *Y, const int incY, void *A, const int lda);
-void cblas_zgerc(const enum CBLAS_ORDER Order, const int M, const int N,
-                 const void *alpha, const void *X, const int incX,
-                 const void *Y, const int incY, void *A, const int lda);
-void cblas_zher(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                const int N, const double alpha, const void *X, const int incX,
-                void *A, const int lda);
-void cblas_zhpr(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                const int N, const double alpha, const void *X,
-                const int incX, void *A);
-void cblas_zher2(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo, const int N,
-                const void *alpha, const void *X, const int incX,
-                const void *Y, const int incY, void *A, const int lda);
-void cblas_zhpr2(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo, const int N,
-                const void *alpha, const void *X, const int incX,
-                const void *Y, const int incY, void *Ap);
+	/*
+	* Extra reference routines provided by ATLAS, but not mandated by the standard
+	*/
+	void cblas_crotg(void *a, void *b, void *c, void *s);
+	void cblas_zrotg(void *a, void *b, void *c, void *s);
+	void cblas_csrot(const int *N, void *X, const int *incX, void *Y, const int *incY,
+		const float *c, const float *s);
+	void cblas_zdrot(const int *N, void *X, const int *incX, void *Y, const int *incY,
+		const double *c, const double *s);
 
-/*
- * ===========================================================================
- * Prototypes for level 3 BLAS
- * ===========================================================================
- */
+	/*
+	* ===========================================================================
+	* Prototypes for level 2 BLAS
+	* ===========================================================================
+	*/
 
-/*
- * Routines with standard 4 prefixes (S, D, C, Z)
- */
-void cblas_sgemm(const enum CBLAS_ORDER Order, const enum CBLAS_TRANSPOSE TransA,
-                 const enum CBLAS_TRANSPOSE TransB, const int M, const int N,
-                 const int K, const float alpha, const float *A,
-                 const int lda, const float *B, const int ldb,
-                 const float beta, float *C, const int ldc);
-void cblas_ssymm(const enum CBLAS_ORDER Order, const enum CBLAS_SIDE Side,
-                 const enum CBLAS_UPLO Uplo, const int M, const int N,
-                 const float alpha, const float *A, const int lda,
-                 const float *B, const int ldb, const float beta,
-                 float *C, const int ldc);
-void cblas_ssyrk(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                 const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
-                 const float alpha, const float *A, const int lda,
-                 const float beta, float *C, const int ldc);
-void cblas_ssyr2k(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                  const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
-                  const float alpha, const float *A, const int lda,
-                  const float *B, const int ldb, const float beta,
-                  float *C, const int ldc);
-void cblas_strmm(const enum CBLAS_ORDER Order, const enum CBLAS_SIDE Side,
-                 const enum CBLAS_UPLO Uplo, const enum CBLAS_TRANSPOSE TransA,
-                 const enum CBLAS_DIAG Diag, const int M, const int N,
-                 const float alpha, const float *A, const int lda,
-                 float *B, const int ldb);
-void cblas_strsm(const enum CBLAS_ORDER Order, const enum CBLAS_SIDE Side,
-                 const enum CBLAS_UPLO Uplo, const enum CBLAS_TRANSPOSE TransA,
-                 const enum CBLAS_DIAG Diag, const int M, const int N,
-                 const float alpha, const float *A, const int lda,
-                 float *B, const int ldb);
+	/*
+	* Routines with standard 4 prefixes (S, D, *c, Z)
+	*/
+	void cblas_sgemv(
+		const char *TransA, const int *M, const int *N,
+		const float *alpha, const float *A, const int *lda,
+		const float *X, const int *incX, const float *beta,
+		float *Y, const int *incY);
+	void cblas_sgbmv(
+		const char *TransA, const int *M, const int *N,
+		const int *KL, const int *KU, const float *alpha,
+		const float *A, const int *lda, const float *X,
+		const int *incX, const float *beta, float *Y, const int *incY);
+	void cblas_strmv( const char *Uplo,
+		const char *TransA, const char *Diag,
+		const int *N, const float *A, const int *lda,
+		float *X, const int *incX);
+	void cblas_stbmv( const char *Uplo,
+		const char *TransA, const char *Diag,
+		const int *N, const int *K, const float *A, const int *lda,
+		float *X, const int *incX);
+	void cblas_stpmv( const char *Uplo,
+		const char *TransA, const char *Diag,
+		const int *N, const float *Ap, float *X, const int *incX);
+	void cblas_strsv( const char *Uplo,
+		const char *TransA, const char *Diag,
+		const int *N, const float *A, const int *lda, float *X,
+		const int *incX);
+	void cblas_stbsv( const char *Uplo,
+		const char *TransA, const char *Diag,
+		const int *N, const int *K, const float *A, const int *lda,
+		float *X, const int *incX);
+	void cblas_stpsv( const char *Uplo,
+		const char *TransA, const char *Diag,
+		const int *N, const float *Ap, float *X, const int *incX);
 
-void cblas_dgemm(const enum CBLAS_ORDER Order, const enum CBLAS_TRANSPOSE TransA,
-                 const enum CBLAS_TRANSPOSE TransB, const int M, const int N,
-                 const int K, const double alpha, const double *A,
-                 const int lda, const double *B, const int ldb,
-                 const double beta, double *C, const int ldc);
-void cblas_dsymm(const enum CBLAS_ORDER Order, const enum CBLAS_SIDE Side,
-                 const enum CBLAS_UPLO Uplo, const int M, const int N,
-                 const double alpha, const double *A, const int lda,
-                 const double *B, const int ldb, const double beta,
-                 double *C, const int ldc);
-void cblas_dsyrk(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                 const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
-                 const double alpha, const double *A, const int lda,
-                 const double beta, double *C, const int ldc);
-void cblas_dsyr2k(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                  const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
-                  const double alpha, const double *A, const int lda,
-                  const double *B, const int ldb, const double beta,
-                  double *C, const int ldc);
-void cblas_dtrmm(const enum CBLAS_ORDER Order, const enum CBLAS_SIDE Side,
-                 const enum CBLAS_UPLO Uplo, const enum CBLAS_TRANSPOSE TransA,
-                 const enum CBLAS_DIAG Diag, const int M, const int N,
-                 const double alpha, const double *A, const int lda,
-                 double *B, const int ldb);
-void cblas_dtrsm(const enum CBLAS_ORDER Order, const enum CBLAS_SIDE Side,
-                 const enum CBLAS_UPLO Uplo, const enum CBLAS_TRANSPOSE TransA,
-                 const enum CBLAS_DIAG Diag, const int M, const int N,
-                 const double alpha, const double *A, const int lda,
-                 double *B, const int ldb);
+	void cblas_dgemv(
+		const char *TransA, const int *M, const int *N,
+		const double *alpha, const double *A, const int *lda,
+		const double *X, const int *incX, const double *beta,
+		double *Y, const int *incY);
+	void cblas_dgbmv(
+		const char *TransA, const int *M, const int *N,
+		const int *KL, const int *KU, const double *alpha,
+		const double *A, const int *lda, const double *X,
+		const int *incX, const double *beta, double *Y, const int *incY);
+	void cblas_dtrmv( const char *Uplo,
+		const char *TransA, const char *Diag,
+		const int *N, const double *A, const int *lda,
+		double *X, const int *incX);
+	void cblas_dtbmv( const char *Uplo,
+		const char *TransA, const char *Diag,
+		const int *N, const int *K, const double *A, const int *lda,
+		double *X, const int *incX);
+	void cblas_dtpmv( const char *Uplo,
+		const char *TransA, const char *Diag,
+		const int *N, const double *Ap, double *X, const int *incX);
+	void cblas_dtrsv( const char *Uplo,
+		const char *TransA, const char *Diag,
+		const int *N, const double *A, const int *lda, double *X,
+		const int *incX);
+	void cblas_dtbsv( const char *Uplo,
+		const char *TransA, const char *Diag,
+		const int *N, const int *K, const double *A, const int *lda,
+		double *X, const int *incX);
+	void cblas_dtpsv( const char *Uplo,
+		const char *TransA, const char *Diag,
+		const int *N, const double *Ap, double *X, const int *incX);
 
-void cblas_cgemm(const enum CBLAS_ORDER Order, const enum CBLAS_TRANSPOSE TransA,
-                 const enum CBLAS_TRANSPOSE TransB, const int M, const int N,
-                 const int K, const void *alpha, const void *A,
-                 const int lda, const void *B, const int ldb,
-                 const void *beta, void *C, const int ldc);
-void cblas_csymm(const enum CBLAS_ORDER Order, const enum CBLAS_SIDE Side,
-                 const enum CBLAS_UPLO Uplo, const int M, const int N,
-                 const void *alpha, const void *A, const int lda,
-                 const void *B, const int ldb, const void *beta,
-                 void *C, const int ldc);
-void cblas_csyrk(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                 const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
-                 const void *alpha, const void *A, const int lda,
-                 const void *beta, void *C, const int ldc);
-void cblas_csyr2k(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                  const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
-                  const void *alpha, const void *A, const int lda,
-                  const void *B, const int ldb, const void *beta,
-                  void *C, const int ldc);
-void cblas_ctrmm(const enum CBLAS_ORDER Order, const enum CBLAS_SIDE Side,
-                 const enum CBLAS_UPLO Uplo, const enum CBLAS_TRANSPOSE TransA,
-                 const enum CBLAS_DIAG Diag, const int M, const int N,
-                 const void *alpha, const void *A, const int lda,
-                 void *B, const int ldb);
-void cblas_ctrsm(const enum CBLAS_ORDER Order, const enum CBLAS_SIDE Side,
-                 const enum CBLAS_UPLO Uplo, const enum CBLAS_TRANSPOSE TransA,
-                 const enum CBLAS_DIAG Diag, const int M, const int N,
-                 const void *alpha, const void *A, const int lda,
-                 void *B, const int ldb);
+	void cblas_cgemv(
+		const char *TransA, const int *M, const int *N,
+		const void *alpha, const void *A, const int *lda,
+		const void *X, const int *incX, const void *beta,
+		void *Y, const int *incY);
+	void cblas_cgbmv(
+		const char *TransA, const int *M, const int *N,
+		const int *KL, const int *KU, const void *alpha,
+		const void *A, const int *lda, const void *X,
+		const int *incX, const void *beta, void *Y, const int *incY);
+	void cblas_ctrmv( const char *Uplo,
+		const char *TransA, const char *Diag,
+		const int *N, const void *A, const int *lda,
+		void *X, const int *incX);
+	void cblas_ctbmv( const char *Uplo,
+		const char *TransA, const char *Diag,
+		const int *N, const int *K, const void *A, const int *lda,
+		void *X, const int *incX);
+	void cblas_ctpmv( const char *Uplo,
+		const char *TransA, const char *Diag,
+		const int *N, const void *Ap, void *X, const int *incX);
+	void cblas_ctrsv( const char *Uplo,
+		const char *TransA, const char *Diag,
+		const int *N, const void *A, const int *lda, void *X,
+		const int *incX);
+	void cblas_ctbsv( const char *Uplo,
+		const char *TransA, const char *Diag,
+		const int *N, const int *K, const void *A, const int *lda,
+		void *X, const int *incX);
+	void cblas_ctpsv( const char *Uplo,
+		const char *TransA, const char *Diag,
+		const int *N, const void *Ap, void *X, const int *incX);
 
-void cblas_zgemm(const enum CBLAS_ORDER Order, const enum CBLAS_TRANSPOSE TransA,
-                 const enum CBLAS_TRANSPOSE TransB, const int M, const int N,
-                 const int K, const void *alpha, const void *A,
-                 const int lda, const void *B, const int ldb,
-                 const void *beta, void *C, const int ldc);
-void cblas_zsymm(const enum CBLAS_ORDER Order, const enum CBLAS_SIDE Side,
-                 const enum CBLAS_UPLO Uplo, const int M, const int N,
-                 const void *alpha, const void *A, const int lda,
-                 const void *B, const int ldb, const void *beta,
-                 void *C, const int ldc);
-void cblas_zsyrk(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                 const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
-                 const void *alpha, const void *A, const int lda,
-                 const void *beta, void *C, const int ldc);
-void cblas_zsyr2k(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                  const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
-                  const void *alpha, const void *A, const int lda,
-                  const void *B, const int ldb, const void *beta,
-                  void *C, const int ldc);
-void cblas_ztrmm(const enum CBLAS_ORDER Order, const enum CBLAS_SIDE Side,
-                 const enum CBLAS_UPLO Uplo, const enum CBLAS_TRANSPOSE TransA,
-                 const enum CBLAS_DIAG Diag, const int M, const int N,
-                 const void *alpha, const void *A, const int lda,
-                 void *B, const int ldb);
-void cblas_ztrsm(const enum CBLAS_ORDER Order, const enum CBLAS_SIDE Side,
-                 const enum CBLAS_UPLO Uplo, const enum CBLAS_TRANSPOSE TransA,
-                 const enum CBLAS_DIAG Diag, const int M, const int N,
-                 const void *alpha, const void *A, const int lda,
-                 void *B, const int ldb);
+	void cblas_zgemv(
+		const char *TransA, const int *M, const int *N,
+		const void *alpha, const void *A, const int *lda,
+		const void *X, const int *incX, const void *beta,
+		void *Y, const int *incY);
+	void cblas_zgbmv(
+		const char *TransA, const int *M, const int *N,
+		const int *KL, const int *KU, const void *alpha,
+		const void *A, const int *lda, const void *X,
+		const int *incX, const void *beta, void *Y, const int *incY);
+	void cblas_ztrmv( const char *Uplo,
+		const char *TransA, const char *Diag,
+		const int *N, const void *A, const int *lda,
+		void *X, const int *incX);
+	void cblas_ztbmv( const char *Uplo,
+		const char *TransA, const char *Diag,
+		const int *N, const int *K, const void *A, const int *lda,
+		void *X, const int *incX);
+	void cblas_ztpmv( const char *Uplo,
+		const char *TransA, const char *Diag,
+		const int *N, const void *Ap, void *X, const int *incX);
+	void cblas_ztrsv( const char *Uplo,
+		const char *TransA, const char *Diag,
+		const int *N, const void *A, const int *lda, void *X,
+		const int *incX);
+	void cblas_ztbsv( const char *Uplo,
+		const char *TransA, const char *Diag,
+		const int *N, const int *K, const void *A, const int *lda,
+		void *X, const int *incX);
+	void cblas_ztpsv( const char *Uplo,
+		const char *TransA, const char *Diag,
+		const int *N, const void *Ap, void *X, const int *incX);
 
 
-/*
- * Routines with prefixes C and Z only
- */
-void cblas_chemm(const enum CBLAS_ORDER Order, const enum CBLAS_SIDE Side,
-                 const enum CBLAS_UPLO Uplo, const int M, const int N,
-                 const void *alpha, const void *A, const int lda,
-                 const void *B, const int ldb, const void *beta,
-                 void *C, const int ldc);
-void cblas_cherk(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                 const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
-                 const float alpha, const void *A, const int lda,
-                 const float beta, void *C, const int ldc);
-void cblas_cher2k(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                  const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
-                  const void *alpha, const void *A, const int lda,
-                  const void *B, const int ldb, const float beta,
-                  void *C, const int ldc);
-void cblas_zhemm(const enum CBLAS_ORDER Order, const enum CBLAS_SIDE Side,
-                 const enum CBLAS_UPLO Uplo, const int M, const int N,
-                 const void *alpha, const void *A, const int lda,
-                 const void *B, const int ldb, const void *beta,
-                 void *C, const int ldc);
-void cblas_zherk(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                 const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
-                 const double alpha, const void *A, const int lda,
-                 const double beta, void *C, const int ldc);
-void cblas_zher2k(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
-                  const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
-                  const void *alpha, const void *A, const int lda,
-                  const void *B, const int ldb, const double beta,
-                  void *C, const int ldc);
+	/*
+	* Routines with S and D prefixes only
+	*/
+	void cblas_ssymv( const char *Uplo,
+		const int *N, const float *alpha, const float *A,
+		const int *lda, const float *X, const int *incX,
+		const float *beta, float *Y, const int *incY);
+	void cblas_ssbmv( const char *Uplo,
+		const int *N, const int *K, const float *alpha, const float *A,
+		const int *lda, const float *X, const int *incX,
+		const float *beta, float *Y, const int *incY);
+	void cblas_sspmv( const char *Uplo,
+		const int *N, const float *alpha, const float *Ap,
+		const float *X, const int *incX,
+		const float *beta, float *Y, const int *incY);
+	void cblas_sger( const int *M, const int *N,
+		const float *alpha, const float *X, const int *incX,
+		const float *Y, const int *incY, float *A, const int *lda);
+	void cblas_ssyr( const char *Uplo,
+		const int *N, const float *alpha, const float *X,
+		const int *incX, float *A, const int *lda);
+	void cblas_sspr( const char *Uplo,
+		const int *N, const float *alpha, const float *X,
+		const int *incX, float *Ap);
+	void cblas_ssyr2( const char *Uplo,
+		const int *N, const float *alpha, const float *X,
+		const int *incX, const float *Y, const int *incY, float *A,
+		const int *lda);
+	void cblas_sspr2( const char *Uplo,
+		const int *N, const float *alpha, const float *X,
+		const int *incX, const float *Y, const int *incY, float *A);
 
-int cblas_errprn(int ierr, int info, char *form, ...);
+	void cblas_dsymv( const char *Uplo,
+		const int *N, const double *alpha, const double *A,
+		const int *lda, const double *X, const int *incX,
+		const double *beta, double *Y, const int *incY);
+	void cblas_dsbmv( const char *Uplo,
+		const int *N, const int *K, const double *alpha, const double *A,
+		const int *lda, const double *X, const int *incX,
+		const double *beta, double *Y, const int *incY);
+	void cblas_dspmv( const char *Uplo,
+		const int *N, const double *alpha, const double *Ap,
+		const double *X, const int *incX,
+		const double *beta, double *Y, const int *incY);
+	void cblas_dger( const int *M, const int *N,
+		const double *alpha, const double *X, const int *incX,
+		const double *Y, const int *incY, double *A, const int *lda);
+	void cblas_dsyr( const char *Uplo,
+		const int *N, const double *alpha, const double *X,
+		const int *incX, double *A, const int *lda);
+	void cblas_dspr( const char *Uplo,
+		const int *N, const double *alpha, const double *X,
+		const int *incX, double *Ap);
+	void cblas_dsyr2( const char *Uplo,
+		const int *N, const double *alpha, const double *X,
+		const int *incX, const double *Y, const int *incY, double *A,
+		const int *lda);
+	void cblas_dspr2( const char *Uplo,
+		const int *N, const double *alpha, const double *X,
+		const int *incX, const double *Y, const int *incY, double *A);
+
+
+	/*
+	* Routines with C and Z prefixes only
+	*/
+	void cblas_chemv( const char *Uplo,
+		const int *N, const void *alpha, const void *A,
+		const int *lda, const void *X, const int *incX,
+		const void *beta, void *Y, const int *incY);
+	void cblas_chbmv( const char *Uplo,
+		const int *N, const int *K, const void *alpha, const void *A,
+		const int *lda, const void *X, const int *incX,
+		const void *beta, void *Y, const int *incY);
+	void cblas_chpmv( const char *Uplo,
+		const int *N, const void *alpha, const void *Ap,
+		const void *X, const int *incX,
+		const void *beta, void *Y, const int *incY);
+	void cblas_cgeru( const int *M, const int *N,
+		const void *alpha, const void *X, const int *incX,
+		const void *Y, const int *incY, void *A, const int *lda);
+	void cblas_cgerc( const int *M, const int *N,
+		const void *alpha, const void *X, const int *incX,
+		const void *Y, const int *incY, void *A, const int *lda);
+	void cblas_cher( const char *Uplo,
+		const int *N, const float *alpha, const void *X, const int *incX,
+		void *A, const int *lda);
+	void cblas_chpr( const char *Uplo,
+		const int *N, const float *alpha, const void *X,
+		const int *incX, void *A);
+	void cblas_cher2( const char *Uplo, const int *N,
+		const void *alpha, const void *X, const int *incX,
+		const void *Y, const int *incY, void *A, const int *lda);
+	void cblas_chpr2( const char *Uplo, const int *N,
+		const void *alpha, const void *X, const int *incX,
+		const void *Y, const int *incY, void *Ap);
+
+	void cblas_zhemv( const char *Uplo,
+		const int *N, const void *alpha, const void *A,
+		const int *lda, const void *X, const int *incX,
+		const void *beta, void *Y, const int *incY);
+	void cblas_zhbmv( const char *Uplo,
+		const int *N, const int *K, const void *alpha, const void *A,
+		const int *lda, const void *X, const int *incX,
+		const void *beta, void *Y, const int *incY);
+	void cblas_zhpmv( const char *Uplo,
+		const int *N, const void *alpha, const void *Ap,
+		const void *X, const int *incX,
+		const void *beta, void *Y, const int *incY);
+	void cblas_zgeru( const int *M, const int *N,
+		const void *alpha, const void *X, const int *incX,
+		const void *Y, const int *incY, void *A, const int *lda);
+	void cblas_zgerc( const int *M, const int *N,
+		const void *alpha, const void *X, const int *incX,
+		const void *Y, const int *incY, void *A, const int *lda);
+	void cblas_zher( const char *Uplo,
+		const int *N, const double *alpha, const void *X, const int *incX,
+		void *A, const int *lda);
+	void cblas_zhpr( const char *Uplo,
+		const int *N, const double *alpha, const void *X,
+		const int *incX, void *A);
+	void cblas_zher2( const char *Uplo, const int *N,
+		const void *alpha, const void *X, const int *incX,
+		const void *Y, const int *incY, void *A, const int *lda);
+	void cblas_zhpr2( const char *Uplo, const int *N,
+		const void *alpha, const void *X, const int *incX,
+		const void *Y, const int *incY, void *Ap);
+
+	/*
+	* ===========================================================================
+	* Prototypes for level 3 BLAS
+	* ===========================================================================
+	*/
+
+	/*
+	* Routines with standard 4 prefixes (S, D, *c, Z)
+	*/
+	void cblas_sgemm( const char *TransA,
+		const char *TransB, const int *M, const int *N,
+		const int *K, const float *alpha, const float *A,
+		const int *lda, const float *B, const int *ldb,
+		const float *beta, float *c, const int *ldc);
+	void cblas_ssymm( const char *Side,
+		const char *Uplo, const int *M, const int *N,
+		const float *alpha, const float *A, const int *lda,
+		const float *B, const int *ldb, const float *beta,
+		float *c, const int *ldc);
+	void cblas_ssyrk( const char *Uplo,
+		const char *Trans, const int *N, const int *K,
+		const float *alpha, const float *A, const int *lda,
+		const float *beta, float *c, const int *ldc);
+	void cblas_ssyr2k( const char *Uplo,
+		const char *Trans, const int *N, const int *K,
+		const float *alpha, const float *A, const int *lda,
+		const float *B, const int *ldb, const float *beta,
+		float *c, const int *ldc);
+	void cblas_strmm( const char *Side,
+		const char *Uplo, const char *TransA,
+		const char *Diag, const int *M, const int *N,
+		const float *alpha, const float *A, const int *lda,
+		float *B, const int *ldb);
+	void cblas_strsm( const char *Side,
+		const char *Uplo, const char *TransA,
+		const char *Diag, const int *M, const int *N,
+		const float *alpha, const float *A, const int *lda,
+		float *B, const int *ldb);
+
+	void cblas_dgemm( const char *TransA,
+		const char *TransB, const int *M, const int *N,
+		const int *K, const double *alpha, const double *A,
+		const int *lda, const double *B, const int *ldb,
+		const double *beta, double *c, const int *ldc);
+	void cblas_dsymm( const char *Side,
+		const char *Uplo, const int *M, const int *N,
+		const double *alpha, const double *A, const int *lda,
+		const double *B, const int *ldb, const double *beta,
+		double *c, const int *ldc);
+	void cblas_dsyrk( const char *Uplo,
+		const char *Trans, const int *N, const int *K,
+		const double *alpha, const double *A, const int *lda,
+		const double *beta, double *c, const int *ldc);
+	void cblas_dsyr2k( const char *Uplo,
+		const char *Trans, const int *N, const int *K,
+		const double *alpha, const double *A, const int *lda,
+		const double *B, const int *ldb, const double *beta,
+		double *c, const int *ldc);
+	void cblas_dtrmm( const char *Side,
+		const char *Uplo, const char *TransA,
+		const char *Diag, const int *M, const int *N,
+		const double *alpha, const double *A, const int *lda,
+		double *B, const int *ldb);
+	void cblas_dtrsm( const char *Side,
+		const char *Uplo, const char *TransA,
+		const char *Diag, const int *M, const int *N,
+		const double *alpha, const double *A, const int *lda,
+		double *B, const int *ldb);
+
+	void cblas_cgemm( const char *TransA,
+		const char *TransB, const int *M, const int *N,
+		const int *K, const void *alpha, const void *A,
+		const int *lda, const void *B, const int *ldb,
+		const void *beta, void *c, const int *ldc);
+	void cblas_csymm( const char *Side,
+		const char *Uplo, const int *M, const int *N,
+		const void *alpha, const void *A, const int *lda,
+		const void *B, const int *ldb, const void *beta,
+		void *c, const int *ldc);
+	void cblas_csyrk( const char *Uplo,
+		const char *Trans, const int *N, const int *K,
+		const void *alpha, const void *A, const int *lda,
+		const void *beta, void *c, const int *ldc);
+	void cblas_csyr2k( const char *Uplo,
+		const char *Trans, const int *N, const int *K,
+		const void *alpha, const void *A, const int *lda,
+		const void *B, const int *ldb, const void *beta,
+		void *c, const int *ldc);
+	void cblas_ctrmm( const char *Side,
+		const char *Uplo, const char *TransA,
+		const char *Diag, const int *M, const int *N,
+		const void *alpha, const void *A, const int *lda,
+		void *B, const int *ldb);
+	void cblas_ctrsm( const char *Side,
+		const char *Uplo, const char *TransA,
+		const char *Diag, const int *M, const int *N,
+		const void *alpha, const void *A, const int *lda,
+		void *B, const int *ldb);
+
+	void cblas_zgemm( const char *TransA,
+		const char *TransB, const int *M, const int *N,
+		const int *K, const void *alpha, const void *A,
+		const int *lda, const void *B, const int *ldb,
+		const void *beta, void *c, const int *ldc);
+	void cblas_zsymm( const char *Side,
+		const char *Uplo, const int *M, const int *N,
+		const void *alpha, const void *A, const int *lda,
+		const void *B, const int *ldb, const void *beta,
+		void *c, const int *ldc);
+	void cblas_zsyrk( const char *Uplo,
+		const char *Trans, const int *N, const int *K,
+		const void *alpha, const void *A, const int *lda,
+		const void *beta, void *c, const int *ldc);
+	void cblas_zsyr2k( const char *Uplo,
+		const char *Trans, const int *N, const int *K,
+		const void *alpha, const void *A, const int *lda,
+		const void *B, const int *ldb, const void *beta,
+		void *c, const int *ldc);
+	void cblas_ztrmm( const char *Side,
+		const char *Uplo, const char *TransA,
+		const char *Diag, const int *M, const int *N,
+		const void *alpha, const void *A, const int *lda,
+		void *B, const int *ldb);
+	void cblas_ztrsm( const char *Side,
+		const char *Uplo, const char *TransA,
+		const char *Diag, const int *M, const int *N,
+		const void *alpha, const void *A, const int *lda,
+		void *B, const int *ldb);
+
+
+	/*
+	* Routines with prefixes C and Z only
+	*/
+	void cblas_chemm( const char *Side,
+		const char *Uplo, const int *M, const int *N,
+		const void *alpha, const void *A, const int *lda,
+		const void *B, const int *ldb, const void *beta,
+		void *c, const int *ldc);
+	void cblas_cherk( const char *Uplo,
+		const char *Trans, const int *N, const int *K,
+		const float *alpha, const void *A, const int *lda,
+		const float *beta, void *c, const int *ldc);
+	void cblas_cher2k( const char *Uplo,
+		const char *Trans, const int *N, const int *K,
+		const void *alpha, const void *A, const int *lda,
+		const void *B, const int *ldb, const float *beta,
+		void *c, const int *ldc);
+	void cblas_zhemm( const char *Side,
+		const char *Uplo, const int *M, const int *N,
+		const void *alpha, const void *A, const int *lda,
+		const void *B, const int *ldb, const void *beta,
+		void *c, const int *ldc);
+	void cblas_zherk( const char *Uplo,
+		const char *Trans, const int *N, const int *K,
+		const double *alpha, const void *A, const int *lda,
+		const double *beta, void *c, const int *ldc);
+	void cblas_zher2k( const char *Uplo,
+		const char *Trans, const int *N, const int *K,
+		const void *alpha, const void *A, const int *lda,
+		const void *B, const int *ldb, const double *beta,
+		void *c, const int *ldc);
+
+	int cblas_errprn(int *ierr, int *info, char *form, ...);
+
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif  /* end #ifdef CBLAS_ENUM_ONLY */
 #endif


### PR DESCRIPTION
In this commit cblas-wrappwers.h and cblas.h are changed to match our
clapack and blas call function format.

Kaldi-matrix.cc is also changed to fix the same issue.

There are also tiny changes to fix removing pthread.

 Changes to be committed:
	modified:   src/matrix/cblas-wrappers.h
	modified:   src/matrix/kaldi-matrix.cc
	modified:   src/thread/kaldi-barrier.cc
	modified:   src/thread/kaldi-mutex.cc
	modified:   tools/CLAPACK/cblas.h