### PR TITLE
Finish renaming NnetComputeOptions struct field from debug to ddebug.

### DIFF
--- a/src/chainbin/nnet3-chain-acc-lda-stats.cc
+++ b/src/chainbin/nnet3-chain-acc-lda-stats.cc
@@ -50,7 +50,7 @@ class NnetChainLdaStatsAccumulator {
 
     NnetComputeOptions options;
     if (GetVerboseLevel() >= 3)
-      options.debug = true;
+      options.ddebug = true;
     NnetComputer computer(options, computation, nnet_, NULL);
 
     computer.AcceptInputs(nnet_, eg.inputs);

--- a/src/nnet3bin/nnet3-acc-lda-stats.cc
+++ b/src/nnet3bin/nnet3-acc-lda-stats.cc
@@ -42,7 +42,7 @@ class NnetLdaStatsAccumulator {
     const NnetComputation &computation = *(compiler_.Compile(request));
     NnetComputeOptions options;
     if (GetVerboseLevel() >= 3)
-      options.debug = true;
+      options.ddebug = true;
     NnetComputer computer(options, computation, nnet_, NULL);
     
     computer.AcceptInputs(nnet_, eg.io);

--- a/src/nnet3bin/nnet3-compute-from-egs.cc
+++ b/src/nnet3bin/nnet3-compute-from-egs.cc
@@ -43,7 +43,7 @@ class NnetComputerFromEg {
     const NnetComputation &computation = *(compiler_.Compile(request));
     NnetComputeOptions options;
     if (GetVerboseLevel() >= 3)
-      options.debug = true;
+      options.ddebug = true;
     NnetComputer computer(options, computation, nnet_, NULL);
     computer.AcceptInputs(nnet_, eg.io);
     computer.Forward();

--- a/src/nnet3bin/nnet3-discriminative-compute-from-egs.cc
+++ b/src/nnet3bin/nnet3-discriminative-compute-from-egs.cc
@@ -43,7 +43,7 @@ class NnetComputerFromEg {
     const NnetComputation &computation = *(compiler_.Compile(request));
     NnetComputeOptions options;
     if (GetVerboseLevel() >= 3)
-      options.debug = true;
+      options.ddebug = true;
     NnetComputer computer(options, computation, nnet_, NULL);
     computer.AcceptInputs(nnet_, eg.io);
     computer.Forward();


### PR DESCRIPTION
Commit 7c62f72f27119d9d1b55944b7b421f4317ab9e95 renames the `debug` field of the `NnetComputeOptions` struct to `ddebug`, but doesn't replace all references to the old name.  With this patch, I was able to successfully build Kaldi.